### PR TITLE
add method to return the length of consumed data when parsing der cert

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -46,10 +46,14 @@ pub fn parse_cert_len_internal<'a>(cert_der: untrusted::Input<'a>)
     
     let mut reader = untrusted::Reader::new(cert_der);
 
+    let mark1 = reader.mark();
     let (_tbs, _signed_data) = try!(der::nested(&mut reader, der::Tag::Sequence, Error::BadDER,
                 signed_data::parse_signed_data));
+    let mark2 = reader.mark();
 
-    Ok(reader.pos())
+    let cert_input = try!(reader.get_input_between_marks(mark1, mark2).map_err(|_e| Error::BadDER));
+
+    Ok(cert_input.len())
 }
 
 /// Used by `parse_cert` for regular certificates (end-entity and intermediate)

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -40,6 +40,18 @@ pub fn parse_cert<'a>(cert_der: untrusted::Input<'a>,
     parse_cert_internal(cert_der, ee_or_ca, certificate_serial_number)
 }
 
+/// Cert length
+pub fn parse_cert_len_internal<'a>(cert_der: untrusted::Input<'a>)
+        -> Result<usize, Error> {
+    
+    let mut reader = untrusted::Reader::new(cert_der);
+
+    let (_tbs, _signed_data) = try!(der::nested(&mut reader, der::Tag::Sequence, Error::BadDER,
+                signed_data::parse_signed_data));
+
+    Ok(reader.pos())
+}
+
 /// Used by `parse_cert` for regular certificates (end-entity and intermediate)
 /// and by `cert_der_as_trust_anchor` for trust anchors encoded as
 /// certificates.

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -154,6 +154,12 @@ impl <'a> EndEntityCert<'a> {
         })
     }
 
+    /// Parse the ASN.1 DER-encoded X.509 encoding of the certificate
+    /// `cert_der` and return the length in bytes consumed.
+    pub fn cert_len(cert_der: untrusted::Input<'a>) -> Result<usize, Error> {
+        cert::parse_cert_len_internal(cert_der)
+    }
+
     /// Verifies that the end-entity certificate is valid for use by a TLS
     /// server.
     ///

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -155,9 +155,14 @@ impl <'a> EndEntityCert<'a> {
     }
 
     /// Parse the ASN.1 DER-encoded X.509 encoding of the certificate
-    /// `cert_der` and return the length in bytes consumed.
-    pub fn cert_len(cert_der: untrusted::Input<'a>) -> Result<usize, Error> {
-        cert::parse_cert_len_internal(cert_der)
+    /// `cert_der`.
+    pub fn from_reader(cert_der: &mut untrusted::Reader<'a>)
+                -> Result<EndEntityCert<'a>, Error> {
+        Ok(EndEntityCert {
+            inner:
+                try!(cert::parse_cert_from_reader(cert_der,
+                                      cert::EndEntityOrCA::EndEntity))
+        })
     }
 
     /// Verifies that the end-entity certificate is valid for use by a TLS


### PR DESCRIPTION
i want to calculate the length in bytes of a der encoded cert buried in a variable-length packet.
by exposing the reader's byte position i hope to make it possible to read out the number of bytes consumed by the der parser.

see https://github.com/briansmith/untrusted/pull/8