### PR TITLE
Use base64 crate instead of rustc-serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,11 @@ trust_anchor_util = []
 
 [dependencies]
 ring = "0.7"
-rustc-serialize = "0.3.15"
 time = "0.1"
 untrusted = "0.3"
+
+[dev-dependencies]
+base64 = "0.5.0"
 
 [profile.bench]
 opt-level = 3

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -336,7 +336,7 @@ const RSA_PSS_SHA512: AlgorithmIdentifier = AlgorithmIdentifier {
 
 #[cfg(test)]
 mod tests {
-    use rustc_serialize::base64::FromBase64;
+    use base64;
     use std;
     use std::io::BufRead;
     use {der, Error, signed_data};
@@ -631,7 +631,7 @@ mod tests {
             base64.push_str(&line);
         }
 
-        base64.from_base64().unwrap()
+        base64::decode(&base64).unwrap()
     }
 
     static SUPPORTED_ALGORITHMS_IN_TESTS:

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -85,7 +85,7 @@ extern crate ring;
 extern crate time;
 
 #[cfg(test)]
-extern crate rustc_serialize;
+extern crate base64;
 
 extern crate untrusted;
 


### PR DESCRIPTION
For issue #45.

This is also now a dev-dependency, since it's only used in tests.