### PR TITLE
Only check length of serial number, not signedness

### DIFF
--- a/src/der.rs
+++ b/src/der.rs
@@ -95,11 +95,6 @@ pub fn optional_boolean(input: &mut untrusted::Reader) -> Result<bool, Error> {
     })
 }
 
-pub fn positive_integer<'a>(input: &'a mut untrusted::Reader)
-                            -> Result<untrusted::Input<'a>, Error> {
-    ring::der::positive_integer(input).map_err(|_| Error::BadDER)
-}
-
 pub fn small_nonnegative_integer<'a>(input: &'a mut untrusted::Reader)
                                      -> Result<u8, Error> {
     ring::der::small_nonnegative_integer(input).map_err(|_| Error::BadDER)


### PR DESCRIPTION
There are non-conforming CAs in the wild that issue certs with zero or negative serial numbers. RFC5280 also states that such certs should be handled gracefully.