### PR TITLE
Update Ring to 0.14.0-alpha4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ trust_anchor_util = ["std"]
 std = []
 
 [dependencies]
-ring = "0.14.0-alpha2"
+ring = "0.14.0-alpha4"
 untrusted = "0.6.2"
 
 [dev-dependencies]


### PR DESCRIPTION
This updates the Ring dependency to the latest alpha release.

After this PR is merged, I'd love to have another alpha release on crates.io... `0.19.0-alpha1` isn't released yet.