### PR TITLE
Retain the entire `SubjectPublicKeyInfo` structure when parsing.

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -26,7 +26,7 @@ pub struct Cert<'a> {
     pub issuer: untrusted::Input<'a>,
     pub validity: untrusted::Input<'a>,
     pub subject: untrusted::Input<'a>,
-    pub spki: untrusted::Input<'a>,
+    pub spki: der::Value<'a>,
 
     pub basic_constraints: Option<untrusted::Input<'a>>,
     pub eku: Option<untrusted::Input<'a>>,
@@ -71,7 +71,7 @@ pub(crate) fn parse_cert_internal<'a>(
         let issuer = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
         let validity = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
         let subject = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
-        let spki = der::expect_tag_and_get_value(tbs, der::Tag::Sequence)?;
+        let spki = der::expect_tag(tbs, der::Tag::Sequence)?;
 
         // In theory there could be fields [1] issuerUniqueID and [2]
         // subjectUniqueID, but in practice there never are, and to keep the

--- a/src/der.rs
+++ b/src/der.rs
@@ -25,6 +25,35 @@ pub fn expect_tag_and_get_value<'a>(
     ring::io::der::expect_tag_and_get_value(input, tag).map_err(|_| Error::BadDER)
 }
 
+pub struct Value<'a> {
+    tlv: untrusted::Input<'a>,
+    value: untrusted::Input<'a>,
+}
+
+impl<'a> Value<'a> {
+    #[allow(dead_code)] // TODO: remove this.
+    pub fn tlv(&self) -> untrusted::Input<'a> { self.tlv }
+
+    pub fn value(&self) -> untrusted::Input<'a> { self.value }
+}
+
+pub fn expect_tag<'a>(input: &mut untrusted::Reader<'a>, tag: Tag) -> Result<Value<'a>, Error> {
+    let start = input.mark();
+
+    let (actual_tag, value) = read_tag_and_get_value(input)?;
+    if usize::from(tag) != usize::from(actual_tag) {
+        return Err(Error::BadDER);
+    }
+
+    let end = input.mark();
+
+    let tlv = input
+        .get_input_between_marks(start, end)
+        .map_err(|untrusted::EndOfInput| Error::BadDER)?;
+
+    Ok(Value { tlv, value })
+}
+
 #[inline(always)]
 pub fn read_tag_and_get_value<'a>(
     input: &mut untrusted::Reader<'a>,

--- a/src/trust_anchor_util.rs
+++ b/src/trust_anchor_util.rs
@@ -79,7 +79,7 @@ pub fn generate_code_for_trust_anchors(name: &str, trust_anchors: &[TrustAnchor]
 fn trust_anchor_from_cert<'a>(cert: Cert<'a>) -> TrustAnchor<'a> {
     TrustAnchor {
         subject: cert.subject.as_slice_less_safe(),
-        spki: cert.spki.as_slice_less_safe(),
+        spki: cert.spki.value().as_slice_less_safe(),
         name_constraints: cert.name_constraints.map(|nc| nc.as_slice_less_safe()),
     }
 }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -88,7 +88,9 @@ pub fn build_chain(
         // Prevent loops; see RFC 4158 section 5.2.
         let mut prev = cert;
         loop {
-            if potential_issuer.spki == prev.spki && potential_issuer.subject == prev.subject {
+            if potential_issuer.spki.value() == prev.spki.value()
+                && potential_issuer.subject == prev.subject
+            {
                 return Err(Error::UnknownIssuer);
             }
             match &prev.ee_or_ca {
@@ -135,7 +137,7 @@ fn check_signatures(
 
         match &cert.ee_or_ca {
             &EndEntityOrCA::CA(child_cert) => {
-                spki_value = cert.spki;
+                spki_value = cert.spki.value();
                 cert = child_cert;
             },
             &EndEntityOrCA::EndEntity => {

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -236,7 +236,7 @@ impl<'a> EndEntityCert<'a> {
     ) -> Result<(), Error> {
         signed_data::verify_signature(
             signature_alg,
-            self.inner.spki,
+            self.inner.spki.value(),
             untrusted::Input::from(msg),
             untrusted::Input::from(signature),
         )


### PR DESCRIPTION
Retain the tag and value of the `subjectPublicKeyInfo` field so that
the entire `SEQUENCE` can be accessed in future code.