### PR TITLE
convert doc comment to regular comment

### DIFF
--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -553,7 +553,7 @@ mod tests {
                              "rsa-pss-sha256-salt10.pem",
                              Err(Error::UnsupportedSignatureAlgorithm));
 
-    /// Our PSS tests that should work.
+    // Our PSS tests that should work.
     test_verify_signed_data!(
         test_rsa_pss_sha256_salt32,
         "ours/rsa-pss-sha256-salt32.pem",


### PR DESCRIPTION
[rust-lang/rust#57882](https://github.com/rust-lang/rust/pull/57882) is modifying the `unused_doc_comments` lint to fire on mistakenly documented macro expansions. A crater run detected that this crate will break due to this change, likely because of the use of `deny(unused_doc_comments)` or `deny(warnings)`.

While this kind of breakage is allowed under Rust's stability guarantees, I am opening PRs to affected crates to reduce the impact.

This PR protects your crate from future breakage by converting the offending doc comment to a regular comment.