### PR TITLE
fix no_std compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ trust_anchor_util = ["std"]
 std = []
 
 [dependencies]
-ring = "0.16.0"
+ring = { version = "0.16.0", default-features = false, features = ["alloc"] }
 untrusted = "0.7.0"
 
 [dev-dependencies]


### PR DESCRIPTION
the default feature set of ring includes `dev_urandom_fallback` which is not no_std compatible, and we don't actually depend on that feature in webpki.