### PR TITLE
Fix warning about `legacy_directory_ownership`.

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,7 +15,6 @@
 #![deny(box_pointers)]
 #![forbid(
     anonymous_parameters,
-    legacy_directory_ownership,
     missing_copy_implementations,
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
Stop mentioning the now-removed warning.