### PR TITLE
Add as_str to DNSName

### DIFF
--- a/src/name.rs
+++ b/src/name.rs
@@ -42,6 +42,9 @@ pub struct DNSName(String);
 impl DNSName {
     /// Returns a `DNSNameRef` that refers to this `DNSName`.
     pub fn as_ref(&self) -> DNSNameRef { DNSNameRef(self.0.as_bytes()) }
+
+    /// Returns this `DNSName` as `&str`
+    pub fn as_str(&self) -> &str { self.0.as_ref() }
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
There already exists `AsRef<str>` implementation for `DNSName`, but given there is also `as_ref() -> DNSNameRef`, trying to get a `&str` with `dns_name.as_ref()` ends up picking the wrong implementation.

The `AsRef::<str>::as_ref(&source)` alternative works, but isn't that pretty!

The `as_str()` is somewhat idiomatic solution to this (see `String::as_str()` for an example).

(The `AsRef::<str>::...` is a suitable workaround, which I've already unleashed upon my codebase so I don't _really_ need this PR to land if there's a reason to reject it.)

> Pull requests must explicitly indicate who owns the copyright to the code being contributed and that the code is being licensed under the same terms as the existing webpki code.

I don't believe the changes are significant enough to be covered by copyright, but to avoid any doubt, if they were, I'd be the owner and I'll license them under the same terms as the exiting webpki code.