### PR TITLE
Implement TryFrom for a variety of types

### DIFF
--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -108,10 +108,12 @@ pub struct EndEntityCert<'a> {
     inner: cert::Cert<'a>,
 }
 
-impl<'a> EndEntityCert<'a> {
+impl<'a> core::convert::TryFrom<&'a [u8]> for EndEntityCert<'a> {
+    type Error = Error;
+
     /// Parse the ASN.1 DER-encoded X.509 encoding of the certificate
     /// `cert_der`.
-    pub fn from(cert_der: &'a [u8]) -> Result<Self, Error> {
+    fn try_from(cert_der: &'a [u8]) -> Result<Self, Self::Error> {
         Ok(Self {
             inner: cert::parse_cert(
                 untrusted::Input::from(cert_der),
@@ -119,7 +121,9 @@ impl<'a> EndEntityCert<'a> {
             )?,
         })
     }
+}
 
+impl<'a> EndEntityCert<'a> {
     /// Verifies that the end-entity certificate is valid for use by a TLS
     /// server.
     ///

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,6 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use core::convert::TryFrom;
 extern crate webpki;
 
 static ALL_SIGALGS: &[&webpki::SignatureAlgorithm] = &[
@@ -35,7 +36,7 @@ static ALL_SIGALGS: &[&webpki::SignatureAlgorithm] = &[
 #[cfg(feature = "alloc")]
 #[test]
 pub fn netflix() {
-    let ee = include_bytes!("netflix/ee.der");
+    let ee: &[u8] = include_bytes!("netflix/ee.der");
     let inter = include_bytes!("netflix/inter.der");
     let ca = include_bytes!("netflix/ca.der");
 
@@ -45,7 +46,7 @@ pub fn netflix() {
     #[allow(clippy::unreadable_literal)] // TODO: Make this clear.
     let time = webpki::Time::from_seconds_since_unix_epoch(1492441716);
 
-    let cert = webpki::EndEntityCert::from(ee).unwrap();
+    let cert = webpki::EndEntityCert::try_from(ee).unwrap();
     assert_eq!(
         Ok(()),
         cert.verify_is_valid_tls_server_cert(ALL_SIGALGS, &anchors, &[inter], time)
@@ -54,7 +55,7 @@ pub fn netflix() {
 
 #[test]
 pub fn ed25519() {
-    let ee = include_bytes!("ed25519/ee.der");
+    let ee: &[u8] = include_bytes!("ed25519/ee.der");
     let ca = include_bytes!("ed25519/ca.der");
 
     let anchors = vec![webpki::trust_anchor_util::cert_der_as_trust_anchor(ca).unwrap()];
@@ -63,7 +64,7 @@ pub fn ed25519() {
     #[allow(clippy::unreadable_literal)] // TODO: Make this clear.
     let time = webpki::Time::from_seconds_since_unix_epoch(1547363522);
 
-    let cert = webpki::EndEntityCert::from(ee).unwrap();
+    let cert = webpki::EndEntityCert::try_from(ee).unwrap();
     assert_eq!(
         Ok(()),
         cert.verify_is_valid_tls_server_cert(ALL_SIGALGS, &anchors, &[], time)


### PR DESCRIPTION
This adds TryFrom implementations for a variety of types that already had equivalent implementations, but outside of an `imply TryFrom`.

I'm unsure about adding `#[deprecated]`, since those who elevate deprecation warning to compile error may have to `use core::convert::TryFrom`.

related to #73 