### PR TITLE
CI/CD: Add `clippy` jobs, use Clippy for "warnings as errors", fix Rust Nightly compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,30 @@ on:
   pull_request:
   push:
 jobs:
+  clippy:
+    # Don't run duplicate `push` jobs for the repo owner's PRs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        rust_channel:
+          # MSRV
+          - 1.37.0
+          - stable
+
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust_channel }}
+          profile: minimal
+          components: clippy
+
+      - uses: actions/checkout@v2
+
+      - run: cargo +${{ matrix.rust_channel }} clippy --all-features ---all-targets -- --deny warnings
+
   audit:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -93,6 +93,7 @@ fn days_in_feb(year: u64) -> u64 {
     }
 }
 
+#[allow(clippy::unreadable_literal)] // TODO: Make this clear.
 const DAYS_BEFORE_UNIX_EPOCH_AD: u64 = 719162;
 
 #[cfg(test)]
@@ -126,6 +127,7 @@ mod tests {
         assert_eq!(days_in_month(2100, 2), 28);
     }
 
+    #[allow(clippy::unreadable_literal)] // TODO: Make this clear.
     #[test]
     fn test_time_from_ymdhms_utc() {
         use super::{time_from_ymdhms_utc, Time};

--- a/src/der.rs
+++ b/src/der.rs
@@ -141,7 +141,7 @@ pub fn time_choice<'a>(input: &mut untrusted::Reader<'a>) -> Result<time::Time, 
         if b < b'0' || b > b'9' {
             return Err(Error::BadDERTime);
         }
-        Ok((b - b'0') as u64)
+        Ok(u64::from(b - b'0'))
     }
 
     fn read_two_digits(inner: &mut untrusted::Reader, min: u64, max: u64) -> Result<u64, Error> {

--- a/src/der.rs
+++ b/src/der.rs
@@ -124,11 +124,11 @@ pub fn positive_integer<'a>(input: &'a mut untrusted::Reader) -> Result<Positive
     ring::io::der::positive_integer(input).map_err(|_| Error::BadDER)
 }
 
-pub fn small_nonnegative_integer<'a>(input: &'a mut untrusted::Reader) -> Result<u8, Error> {
+pub fn small_nonnegative_integer(input: &mut untrusted::Reader) -> Result<u8, Error> {
     ring::io::der::small_nonnegative_integer(input).map_err(|_| Error::BadDER)
 }
 
-pub fn time_choice<'a>(input: &mut untrusted::Reader<'a>) -> Result<time::Time, Error> {
+pub fn time_choice(input: &mut untrusted::Reader) -> Result<time::Time, Error> {
     let is_utc_time = input.peek(Tag::UTCTime as u8);
     let expected_tag = if is_utc_time {
         Tag::UTCTime

--- a/src/name.rs
+++ b/src/name.rs
@@ -375,7 +375,7 @@ fn presented_ip_address_matches_constraint(
         }
     }
 
-    return Ok(true);
+    Ok(true)
 }
 
 #[derive(Clone, Copy)]
@@ -727,7 +727,7 @@ fn presented_dns_id_matches_reference_dns_id_internal(
     assert!(presented.at_end());
     assert!(reference.at_end());
 
-    return Some(true);
+    Some(true)
 }
 
 #[inline]

--- a/src/name.rs
+++ b/src/name.rs
@@ -435,6 +435,7 @@ enum GeneralName<'a> {
 
 fn general_name<'a>(input: &mut untrusted::Reader<'a>) -> Result<GeneralName<'a>, Error> {
     use ring::io::der::{CONSTRUCTED, CONTEXT_SPECIFIC};
+    #[allow(clippy::identity_op)]
     const OTHER_NAME_TAG: u8 = CONTEXT_SPECIFIC | CONSTRUCTED | 0;
     const RFC822_NAME_TAG: u8 = CONTEXT_SPECIFIC | 1;
     const DNS_NAME_TAG: u8 = CONTEXT_SPECIFIC | 2;

--- a/src/name.rs
+++ b/src/name.rs
@@ -16,7 +16,6 @@ use crate::{
     cert::{Cert, EndEntityOrCA},
     der, Error,
 };
-use core;
 
 /// A DNS Name suitable for use in the TLS Server Name Indication (SNI)
 /// extension and/or for use as the reference hostname for which to verify a

--- a/src/name.rs
+++ b/src/name.rs
@@ -623,7 +623,7 @@ fn presented_dns_id_matches_reference_dns_id_internal(
         IDRole::ReferenceID => (),
 
         IDRole::NameConstraint if presented_dns_id.len() > reference_dns_id.len() => {
-            if reference_dns_id.len() == 0 {
+            if reference_dns_id.is_empty() {
                 // An empty constraint matches everything.
                 return Some(true);
             }

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -345,7 +345,6 @@ const ED_25519: AlgorithmIdentifier = AlgorithmIdentifier {
 #[cfg(test)]
 mod tests {
     use crate::{der, signed_data, Error};
-    use base64;
 
     use std::{self, io::BufRead, string::String, vec::Vec};
 

--- a/src/trust_anchor_util.rs
+++ b/src/trust_anchor_util.rs
@@ -47,8 +47,8 @@ pub fn cert_der_as_trust_anchor(cert_der: &[u8]) -> Result<TrustAnchor, Error> {
     }
 }
 
-fn possibly_invalid_certificate_serial_number<'a>(
-    input: &mut untrusted::Reader<'a>,
+fn possibly_invalid_certificate_serial_number(
+    input: &mut untrusted::Reader,
 ) -> Result<(), Error> {
     // https://tools.ietf.org/html/rfc5280#section-4.1.2.2:
     // * Conforming CAs MUST NOT use serialNumber values longer than 20 octets."
@@ -76,7 +76,7 @@ pub fn generate_code_for_trust_anchors(name: &str, trust_anchors: &[TrustAnchor]
     decl + &value
 }
 
-fn trust_anchor_from_cert<'a>(cert: Cert<'a>) -> TrustAnchor<'a> {
+fn trust_anchor_from_cert(cert: Cert) -> TrustAnchor {
     TrustAnchor {
         subject: cert.subject.as_slice_less_safe(),
         spki: cert.spki.value().as_slice_less_safe(),
@@ -85,7 +85,7 @@ fn trust_anchor_from_cert<'a>(cert: Cert<'a>) -> TrustAnchor<'a> {
 }
 
 /// Parses a v1 certificate directly into a TrustAnchor.
-fn parse_cert_v1<'a>(cert_der: untrusted::Input<'a>) -> Result<TrustAnchor<'a>, Error> {
+fn parse_cert_v1(cert_der: untrusted::Input) -> Result<TrustAnchor, Error> {
     // X.509 Certificate: https://tools.ietf.org/html/rfc5280#section-4.1.
     cert_der.read_all(Error::BadDER, |cert_der| {
         der::nested(cert_der, der::Tag::Sequence, Error::BadDER, |cert_der| {

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -250,16 +250,19 @@ pub struct KeyPurposeId {
 // id-kp              OBJECT IDENTIFIER ::= { id-pkix 3 }
 
 // id-kp-serverAuth   OBJECT IDENTIFIER ::= { id-kp 1 }
+#[allow(clippy::identity_op)] // TODO: Make this clearer
 pub static EKU_SERVER_AUTH: KeyPurposeId = KeyPurposeId {
     oid_value: untrusted::Input::from(&[(40 * 1) + 3, 6, 1, 5, 5, 7, 3, 1]),
 };
 
 // id-kp-clientAuth   OBJECT IDENTIFIER ::= { id-kp 2 }
+#[allow(clippy::identity_op)] // TODO: Make this clearer
 pub static EKU_CLIENT_AUTH: KeyPurposeId = KeyPurposeId {
     oid_value: untrusted::Input::from(&[(40 * 1) + 3, 6, 1, 5, 5, 7, 3, 2]),
 };
 
 // id-kp-OCSPSigning  OBJECT IDENTIFIER ::= { id-kp 9 }
+#[allow(clippy::identity_op)] // TODO: Make this clearer
 pub static EKU_OCSP_SIGNING: KeyPurposeId = KeyPurposeId {
     oid_value: untrusted::Input::from(&[(40 * 1) + 3, 6, 1, 5, 5, 7, 3, 9]),
 };

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -94,10 +94,10 @@ pub fn build_chain(
                 return Err(Error::UnknownIssuer);
             }
             match &prev.ee_or_ca {
-                &EndEntityOrCA::EndEntity => {
+                EndEntityOrCA::EndEntity => {
                     break;
                 },
-                &EndEntityOrCA::CA(child_cert) => {
+                EndEntityOrCA::CA(child_cert) => {
                     prev = child_cert;
                 },
             }
@@ -136,11 +136,11 @@ fn check_signatures(
         // TODO: check revocation
 
         match &cert.ee_or_ca {
-            &EndEntityOrCA::CA(child_cert) => {
+            EndEntityOrCA::CA(child_cert) => {
                 spki_value = cert.spki.value();
                 cert = child_cert;
             },
-            &EndEntityOrCA::EndEntity => {
+            EndEntityOrCA::EndEntity => {
                 break;
             },
         }
@@ -203,8 +203,8 @@ enum UsedAsCA {
 
 fn used_as_ca(ee_or_ca: &EndEntityOrCA) -> UsedAsCA {
     match ee_or_ca {
-        &EndEntityOrCA::EndEntity => UsedAsCA::No,
-        &EndEntityOrCA::CA(..) => UsedAsCA::Yes,
+        EndEntityOrCA::EndEntity => UsedAsCA::No,
+        EndEntityOrCA::CA(..) => UsedAsCA::Yes,
     }
 }
 

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -38,6 +38,8 @@
     warnings
 )]
 
+#![allow(clippy::single_match)]
+
 #[cfg(all(test, not(feature = "std")))]
 #[macro_use]
 extern crate std;

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -19,24 +19,6 @@
 
 #![doc(html_root_url = "https://briansmith.org/rustdoc/")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(missing_debug_implementations)]
-// `#[derive(...)]` uses `#[allow(unused_qualifications)]` internally.
-#![deny(unused_qualifications)]
-#![forbid(
-    anonymous_parameters,
-    box_pointers,
-    missing_copy_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
 
 #![allow(clippy::single_match)]
 

--- a/tests/dns_name_tests.rs
+++ b/tests/dns_name_tests.rs
@@ -1,7 +1,5 @@
 // Copyright 2014-2017 Brian Smith.
 
-use webpki;
-
 // (name, is_valid)
 static DNS_NAME_VALIDITY: &[(&[u8], bool)] = &[
     (b"a", true),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,24 +12,6 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#![deny(box_pointers)]
-#![forbid(
-    anonymous_parameters,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications,
-    unused_results,
-    variant_size_differences,
-    warnings
-)]
-
 #[cfg(any(feature = "std", feature = "trust_anchor_util"))]
 extern crate webpki;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -59,6 +59,7 @@ pub fn netflix() {
     let anchors = vec![webpki::trust_anchor_util::cert_der_as_trust_anchor(ca).unwrap()];
     let anchors = webpki::TLSServerTrustAnchors(&anchors);
 
+    #[allow(clippy::unreadable_literal)] // TODO: Make this clear.
     let time = webpki::Time::from_seconds_since_unix_epoch(1492441716);
 
     let cert = webpki::EndEntityCert::from(ee).unwrap();
@@ -76,6 +77,7 @@ pub fn ed25519() {
     let anchors = vec![webpki::trust_anchor_util::cert_der_as_trust_anchor(ca).unwrap()];
     let anchors = webpki::TLSServerTrustAnchors(&anchors);
 
+    #[allow(clippy::unreadable_literal)] // TODO: Make this clear.
     let time = webpki::Time::from_seconds_since_unix_epoch(1547363522);
 
     let cert = webpki::EndEntityCert::from(ee).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -63,9 +63,10 @@ pub fn netflix() {
     let time = webpki::Time::from_seconds_since_unix_epoch(1492441716);
 
     let cert = webpki::EndEntityCert::from(ee).unwrap();
-    let _ = cert
-        .verify_is_valid_tls_server_cert(ALL_SIGALGS, &anchors, &[inter], time)
-        .unwrap();
+    assert_eq!(
+        Ok(()),
+        cert.verify_is_valid_tls_server_cert(ALL_SIGALGS, &anchors, &[inter], time)
+    );
 }
 
 #[cfg(feature = "trust_anchor_util")]
@@ -81,9 +82,10 @@ pub fn ed25519() {
     let time = webpki::Time::from_seconds_since_unix_epoch(1547363522);
 
     let cert = webpki::EndEntityCert::from(ee).unwrap();
-    let _ = cert
-        .verify_is_valid_tls_server_cert(ALL_SIGALGS, &anchors, &[], time)
-        .unwrap();
+    assert_eq!(
+        Ok(()),
+        cert.verify_is_valid_tls_server_cert(ALL_SIGALGS, &anchors, &[], time)
+    );
 }
 
 #[cfg(feature = "trust_anchor_util")]


### PR DESCRIPTION
Address all the Clippy warnings from Clippy 1.37.0 and the current stable Clippy.

Enable Clippy jobs in CI/CD.

Stop using `#[forbid(warnings)]`. Rust Nightly changed its enforcement of it in a way that broke the build. Instead, rely on the Clippy CI/CD jobs to cause merge requests to fail CI/CD on warnings. This is generally a nicer experience for people hacking on webpki.