### PR TITLE
Increase Rust MSRV to 1.46.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,12 @@ jobs:
         rust_channel:
           - stable
           - nightly
-          - 1.37.0 # MSRV
+
+          # MSRV: Rust 1.47 and later have bugs in rustc that prevent some
+          # projects from upgrading past 1.46 yet. So, maintain compatibility
+          # for 1.46 until those bugs are fixed.
+          - 1.46.0
+
           - beta
 
         exclude:
@@ -164,31 +169,31 @@ jobs:
 
           # The MSRV channel doesn't have aarch64-apple-darwin support yet.
           - target: aarch64-apple-darwin
-            rust_channel: 1.37.0
+            rust_channel: 1.46.0
 
           # Only do MSRV testing on release builds.
           - mode: # debug
-            rust_channel: 1.37.0
+            rust_channel: 1.46.0
 
-          # 1.37.0 doesn't support `-Clink-self-contained`.
+          # 1.46.0 doesn't support `-Clink-self-contained`.
           - target: aarch64-unknown-linux-musl
-            rust_channel: 1.37.0
+            rust_channel: 1.46.0
 
-          # 1.37.0 doesn't support `-Clink-self-contained`.
+          # 1.46.0 doesn't support `-Clink-self-contained`.
           - target: armv7-unknown-linux-musleabihf
-            rust_channel: 1.37.0
+            rust_channel: 1.46.0
 
-          # 1.37.0 doesn't support `-Clink-self-contained`.
+          # 1.46.0 doesn't support `-Clink-self-contained`.
           - target: i686-unknown-linux-musl
-            rust_channel: 1.37.0
+            rust_channel: 1.46.0
 
-          # 1.37.0 doesn't support `-Clink-self-contained`.
+          # 1.46.0 doesn't support `-Clink-self-contained`.
           - target: x86_64-unknown-linux-musl
-            rust_channel: 1.37.0
+            rust_channel: 1.46.0
 
           # https://github.com/rust-lang/rust/pull/67429
           - target: x86_64-pc-windows-gnu
-            rust_channel: 1.37.0
+            rust_channel: 1.46.0
 
         include:
           - target: aarch64-apple-darwin


### PR DESCRIPTION
Rust 1.47 and later have bugs in rustc that prevent some projects from
upgrading past 1.46 yet. So, maintain compatibility for 1.46 until those
bugs are fixed.