### PR TITLE
Don't use libstd, and specifically avoid file I/O, in tests.

### DIFF
--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -35,10 +35,6 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-// TODO: Remove this; see https://github.com/briansmith/webpki/issues/167.
-#[cfg(test)]
-extern crate std;
-
 #[macro_use]
 mod der;
 


### PR DESCRIPTION
Previously, the `signed_data` tests could not be run on platforms without libstd.
Now they can be run as long as liballoc is available.