### PR TITLE
DER parser: Add an API for returning a different error for a mismatched tag.

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -101,9 +101,10 @@ pub(crate) fn parse_cert_internal<'a>(
         // special logic for handling critical Netscape Cert Type extensions.
         // That has been intentionally omitted.
 
-        der::nested(
+        der::nested_ex(
             tbs,
             der::Tag::ContextSpecificConstructed3,
+            Error::BadDER,
             Error::BadDER,
             |tagged| {
                 der::nested_of_mut(


### PR DESCRIPTION
Without this new API, it is tempting to try to write:

```
if !input.peek(tag) {
    return Err(mismatched_tag_error);
}
let x = expect_tag_andd_get_value(input, tag, other_error);
```

With this new API, we can achieve the same effect without those
`peek()` calls.