### PR TITLE
Upgrade to cargo-deny 0.8.5.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,9 @@ jobs:
             ~/.cargo/bin/cargo-deny
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-          key: ${{ runner.os }}-v2-cargo-deny-0.8.4
+          key: ${{ runner.os }}-v2-cargo-deny-locked-0.8.5
 
-      - run: cargo install cargo-deny --vers "0.8.4"
+      - run: cargo install cargo-deny --locked --vers "0.8.5"
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Add `--locked` to work around
https://github.com/EmbarkStudios/cargo-deny/issues/331 and because it's
probably the more correct thing to do.