### PR TITLE
Remove `der::Value::tlv`.

### DIFF
--- a/src/der.rs
+++ b/src/der.rs
@@ -27,36 +27,22 @@ pub fn expect_tag_and_get_value<'a>(
 }
 
 pub struct Value<'a> {
-    tlv: untrusted::Input<'a>,
     value: untrusted::Input<'a>,
 }
 
 impl<'a> Value<'a> {
-    #[allow(dead_code)] // TODO: remove this.
-    pub fn tlv(&self) -> untrusted::Input<'a> {
-        self.tlv
-    }
-
     pub fn value(&self) -> untrusted::Input<'a> {
         self.value
     }
 }
 
 pub fn expect_tag<'a>(input: &mut untrusted::Reader<'a>, tag: Tag) -> Result<Value<'a>, Error> {
-    let start = input.mark();
-
     let (actual_tag, value) = read_tag_and_get_value(input)?;
     if usize::from(tag) != usize::from(actual_tag) {
         return Err(Error::BadDER);
     }
 
-    let end = input.mark();
-
-    let tlv = input
-        .get_input_between_marks(start, end)
-        .map_err(|untrusted::EndOfInput| Error::BadDER)?;
-
-    Ok(Value { tlv, value })
+    Ok(Value { value })
 }
 
 #[inline(always)]


### PR DESCRIPTION
This was added as a prerequisite for a feature that hasn't landed yet, but it
is currently unused. Further, it is using deprecated features of `untrusted`.
Remove it. We'll add it back if/when we need it, probably with a different
implementation.