### PR TITLE
Temporarily go back to a webpki-0.21.4-compatible API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license-file = "LICENSE"
 name = "webpki"
 readme = "README.md"
 repository = "https://github.com/briansmith/webpki"
-version = "0.22.0"
+version = "0.21.4"
 
 include = [
     "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ include = [
     "src/signed_data.rs",
     "src/time.rs",
     "src/trust_anchor.rs",
+    "src/trust_anchor_util.rs",
     "src/verify_cert.rs",
     "src/lib.rs",
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,12 @@ all-features = true
 name = "webpki"
 
 [features]
+# TODO: In the next release, make this non-default.
+default = ["std"]
 alloc = ["ring/alloc"]
 std = ["alloc"]
+# TODO: In the next release, remove this.
+trust_anchor_util = ["std"]
 
 [dependencies]
 ring = { version = "0.16.19", default-features = false }

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -67,7 +67,7 @@ fn days_before_year_since_unix_epoch(year: u64) -> Result<u64, Error> {
     // Unix epoch. It is likely that other software won't deal well with
     // certificates that have dates before the epoch.
     if year < 1970 {
-        return Err(Error::BadDerTime);
+        return Err(Error::BadDERTime);
     }
     let days_before_year_ad = days_before_year_ad(year);
     debug_assert!(days_before_year_ad >= DAYS_BEFORE_UNIX_EPOCH_AD);

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -49,16 +49,16 @@ pub(crate) fn parse_cert_internal<'a>(
     ee_or_ca: EndEntityOrCa<'a>,
     serial_number: fn(input: &mut untrusted::Reader<'_>) -> Result<(), Error>,
 ) -> Result<Cert<'a>, Error> {
-    let (tbs, signed_data) = cert_der.read_all(Error::BadDer, |cert_der| {
+    let (tbs, signed_data) = cert_der.read_all(Error::BadDER, |cert_der| {
         der::nested(
             cert_der,
             der::Tag::Sequence,
-            Error::BadDer,
+            Error::BadDER,
             signed_data::parse_signed_data,
         )
     })?;
 
-    tbs.read_all(Error::BadDer, |tbs| {
+    tbs.read_all(Error::BadDER, |tbs| {
         version3(tbs)?;
         serial_number(tbs)?;
 
@@ -110,7 +110,7 @@ pub(crate) fn parse_cert_internal<'a>(
                     tagged,
                     der::Tag::Sequence,
                     der::Tag::Sequence,
-                    Error::BadDer,
+                    Error::BadDER,
                     |extension| {
                         let extn_id = der::expect_tag_and_get_value(extension, der::Tag::OID)?;
                         let critical = der::optional_boolean(extension)?;
@@ -154,7 +154,7 @@ pub fn certificate_serial_number(input: &mut untrusted::Reader) -> Result<(), Er
 
     let value = der::positive_integer(input)?;
     if value.big_endian_without_leading_zero().len() > 20 {
-        return Err(Error::BadDer);
+        return Err(Error::BadDER);
     }
     Ok(())
 }
@@ -215,7 +215,7 @@ fn remember_extension<'a>(
         }
         None => {
             // All the extensions that we care about are wrapped in a SEQUENCE.
-            let sequence_value = value.read_all(Error::BadDer, |value| {
+            let sequence_value = value.read_all(Error::BadDER, |value| {
                 der::expect_tag_and_get_value(value, der::Tag::Sequence)
             })?;
             *out = Some(sequence_value);

--- a/src/der.rs
+++ b/src/der.rs
@@ -23,7 +23,7 @@ pub fn expect_tag_and_get_value<'a>(
     input: &mut untrusted::Reader<'a>,
     tag: Tag,
 ) -> Result<untrusted::Input<'a>, Error> {
-    ring::io::der::expect_tag_and_get_value(input, tag).map_err(|_| Error::BadDer)
+    ring::io::der::expect_tag_and_get_value(input, tag).map_err(|_| Error::BadDER)
 }
 
 pub struct Value<'a> {
@@ -39,7 +39,7 @@ impl<'a> Value<'a> {
 pub fn expect_tag<'a>(input: &mut untrusted::Reader<'a>, tag: Tag) -> Result<Value<'a>, Error> {
     let (actual_tag, value) = read_tag_and_get_value(input)?;
     if usize::from(tag) != usize::from(actual_tag) {
-        return Err(Error::BadDer);
+        return Err(Error::BadDER);
     }
 
     Ok(Value { value })
@@ -49,7 +49,7 @@ pub fn expect_tag<'a>(input: &mut untrusted::Reader<'a>, tag: Tag) -> Result<Val
 pub fn read_tag_and_get_value<'a>(
     input: &mut untrusted::Reader<'a>,
 ) -> Result<(u8, untrusted::Input<'a>), Error> {
-    ring::io::der::read_tag_and_get_value(input).map_err(|_| Error::BadDer)
+    ring::io::der::read_tag_and_get_value(input).map_err(|_| Error::BadDER)
 }
 
 // TODO: investigate taking decoder as a reference to reduce generated code
@@ -78,10 +78,10 @@ where
 pub fn bit_string_with_no_unused_bits<'a>(
     input: &mut untrusted::Reader<'a>,
 ) -> Result<untrusted::Input<'a>, Error> {
-    nested(input, Tag::BitString, Error::BadDer, |value| {
-        let unused_bits_at_end = value.read_byte().map_err(|_| Error::BadDer)?;
+    nested(input, Tag::BitString, Error::BadDER, |value| {
+        let unused_bits_at_end = value.read_byte().map_err(|_| Error::BadDER)?;
         if unused_bits_at_end != 0 {
-            return Err(Error::BadDer);
+            return Err(Error::BadDER);
         }
         Ok(value.read_bytes_to_end())
     })
@@ -93,21 +93,21 @@ pub fn optional_boolean(input: &mut untrusted::Reader) -> Result<bool, Error> {
     if !input.peek(Tag::Boolean.into()) {
         return Ok(false);
     }
-    nested(input, Tag::Boolean, Error::BadDer, |input| {
+    nested(input, Tag::Boolean, Error::BadDER, |input| {
         match input.read_byte() {
             Ok(0xff) => Ok(true),
             Ok(0x00) => Ok(false),
-            _ => Err(Error::BadDer),
+            _ => Err(Error::BadDER),
         }
     })
 }
 
 pub fn positive_integer<'a>(input: &'a mut untrusted::Reader) -> Result<Positive<'a>, Error> {
-    ring::io::der::positive_integer(input).map_err(|_| Error::BadDer)
+    ring::io::der::positive_integer(input).map_err(|_| Error::BadDER)
 }
 
 pub fn small_nonnegative_integer(input: &mut untrusted::Reader) -> Result<u8, Error> {
-    ring::io::der::small_nonnegative_integer(input).map_err(|_| Error::BadDer)
+    ring::io::der::small_nonnegative_integer(input).map_err(|_| Error::BadDER)
 }
 
 pub fn time_choice(input: &mut untrusted::Reader) -> Result<time::Time, Error> {
@@ -120,11 +120,11 @@ pub fn time_choice(input: &mut untrusted::Reader) -> Result<time::Time, Error> {
 
     fn read_digit(inner: &mut untrusted::Reader) -> Result<u64, Error> {
         const DIGIT: core::ops::RangeInclusive<u8> = b'0'..=b'9';
-        let b = inner.read_byte().map_err(|_| Error::BadDerTime)?;
+        let b = inner.read_byte().map_err(|_| Error::BadDERTime)?;
         if DIGIT.contains(&b) {
             return Ok(u64::from(b - DIGIT.start()));
         }
-        Err(Error::BadDerTime)
+        Err(Error::BadDERTime)
     }
 
     fn read_two_digits(inner: &mut untrusted::Reader, min: u64, max: u64) -> Result<u64, Error> {
@@ -132,12 +132,12 @@ pub fn time_choice(input: &mut untrusted::Reader) -> Result<time::Time, Error> {
         let lo = read_digit(inner)?;
         let value = (hi * 10) + lo;
         if value < min || value > max {
-            return Err(Error::BadDerTime);
+            return Err(Error::BadDERTime);
         }
         Ok(value)
     }
 
-    nested(input, expected_tag, Error::BadDer, |value| {
+    nested(input, expected_tag, Error::BadDER, |value| {
         let (year_hi, year_lo) = if is_utc_time {
             let lo = read_two_digits(value, 0, 99)?;
             let hi = if lo >= 50 { 19 } else { 20 };
@@ -156,9 +156,9 @@ pub fn time_choice(input: &mut untrusted::Reader) -> Result<time::Time, Error> {
         let minutes = read_two_digits(value, 0, 59)?;
         let seconds = read_two_digits(value, 0, 59)?;
 
-        let time_zone = value.read_byte().map_err(|_| Error::BadDerTime)?;
+        let time_zone = value.read_byte().map_err(|_| Error::BadDERTime)?;
         if time_zone != b'Z' {
-            return Err(Error::BadDerTime);
+            return Err(Error::BadDERTime);
         }
 
         calendar::time_from_ymdhms_utc(year, month, day_of_month, hours, minutes, seconds)

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -13,9 +13,10 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{
-    cert, name, signed_data, verify_cert, DnsNameRef, Error, SignatureAlgorithm, Time,
-    TlsClientTrustAnchors, TlsServerTrustAnchors,
+    cert, name, signed_data, verify_cert, DnsNameRef, Error, SignatureAlgorithm,
+    TLSClientTrustAnchors, TLSServerTrustAnchors, Time,
 };
+use core::convert::TryFrom;
 
 /// An end-entity certificate.
 ///
@@ -56,7 +57,7 @@ pub struct EndEntityCert<'a> {
     inner: cert::Cert<'a>,
 }
 
-impl<'a> core::convert::TryFrom<&'a [u8]> for EndEntityCert<'a> {
+impl<'a> TryFrom<&'a [u8]> for EndEntityCert<'a> {
     type Error = Error;
 
     /// Parse the ASN.1 DER-encoded X.509 encoding of the certificate
@@ -72,6 +73,12 @@ impl<'a> core::convert::TryFrom<&'a [u8]> for EndEntityCert<'a> {
 }
 
 impl<'a> EndEntityCert<'a> {
+    /// Deprecated. Use `TryFrom::try_from`.
+    #[deprecated(note = "Use TryFrom::try_from")]
+    pub fn from(cert_der: &'a [u8]) -> Result<Self, Error> {
+        TryFrom::try_from(cert_der)
+    }
+
     pub(super) fn inner(&self) -> &cert::Cert {
         &self.inner
     }
@@ -89,7 +96,7 @@ impl<'a> EndEntityCert<'a> {
     pub fn verify_is_valid_tls_server_cert(
         &self,
         supported_sig_algs: &[&SignatureAlgorithm],
-        &TlsServerTrustAnchors(trust_anchors): &TlsServerTrustAnchors,
+        &TLSServerTrustAnchors(trust_anchors): &TLSServerTrustAnchors,
         intermediate_certs: &[&[u8]],
         time: Time,
     ) -> Result<(), Error> {
@@ -121,7 +128,7 @@ impl<'a> EndEntityCert<'a> {
     pub fn verify_is_valid_tls_client_cert(
         &self,
         supported_sig_algs: &[&SignatureAlgorithm],
-        &TlsClientTrustAnchors(trust_anchors): &TlsClientTrustAnchors,
+        &TLSClientTrustAnchors(trust_anchors): &TLSClientTrustAnchors,
         intermediate_certs: &[&[u8]],
         time: Time,
     ) -> Result<(), Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,10 +18,12 @@ use core::fmt;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Error {
     /// The encoding of some ASN.1 DER-encoded item is invalid.
-    BadDer,
+    // TODO: Rename to `BadDer` in the next release.
+    BadDER,
 
     /// The encoding of an ASN.1 DER-encoded time is invalid.
-    BadDerTime,
+    // TODO: Rename to `BadDerTime` in the next release.
+    BadDERTime,
 
     /// A CA certificate is being used as an end-entity certificate.
     CaUsedAsEndEntity,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use {
         ECDSA_P384_SHA384, ED25519,
     },
     time::Time,
-    trust_anchor::{TlsClientTrustAnchors, TlsServerTrustAnchors, TrustAnchor},
+    trust_anchor::{TLSClientTrustAnchors, TLSServerTrustAnchors, TrustAnchor},
 };
 
 #[cfg(feature = "alloc")]
@@ -80,11 +80,3 @@ pub type DNSNameRef<'a> = DnsNameRef<'a>;
 #[deprecated(note = "use InvalidDnsNameError")]
 #[allow(missing_docs, unknown_lints, clippy::upper_case_acronyms)]
 pub type InvalidDNSNameError = InvalidDnsNameError;
-
-#[deprecated(note = "use TlsServerTrustAnchors")]
-#[allow(missing_docs, unknown_lints, clippy::upper_case_acronyms)]
-pub type TLSServerTrustAnchors<'a> = TlsServerTrustAnchors<'a>;
-
-#[deprecated(note = "use TlsClientTrustAnchors")]
-#[allow(missing_docs, unknown_lints, clippy::upper_case_acronyms)]
-pub type TLSClientTrustAnchors<'a> = TlsClientTrustAnchors<'a>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ mod name;
 mod signed_data;
 mod time;
 mod trust_anchor;
+pub mod trust_anchor_util;
 
 mod verify_cert;
 
@@ -75,6 +76,10 @@ pub type DNSName = DnsName;
 #[deprecated(note = "use DnsNameRef")]
 #[allow(missing_docs, unknown_lints, clippy::upper_case_acronyms)]
 pub type DNSNameRef<'a> = DnsNameRef<'a>;
+
+#[deprecated(note = "use InvalidDnsNameError")]
+#[allow(missing_docs, unknown_lints, clippy::upper_case_acronyms)]
+pub type InvalidDNSNameError = InvalidDnsNameError;
 
 #[deprecated(note = "use TlsServerTrustAnchors")]
 #[allow(missing_docs, unknown_lints, clippy::upper_case_acronyms)]

--- a/src/name/ip_address.rs
+++ b/src/name/ip_address.rs
@@ -28,10 +28,10 @@ pub(super) fn presented_id_matches_constraint(
     constraint: untrusted::Input,
 ) -> Result<bool, Error> {
     if name.len() != 4 && name.len() != 16 {
-        return Err(Error::BadDer);
+        return Err(Error::BadDER);
     }
     if constraint.len() != 8 && constraint.len() != 32 {
-        return Err(Error::BadDer);
+        return Err(Error::BadDER);
     }
 
     // an IPv4 address never matches an IPv6 constraint, and vice versa.
@@ -39,7 +39,7 @@ pub(super) fn presented_id_matches_constraint(
         return Ok(false);
     }
 
-    let (constraint_address, constraint_mask) = constraint.read_all(Error::BadDer, |value| {
+    let (constraint_address, constraint_mask) = constraint.read_all(Error::BadDER, |value| {
         let address = value.read_bytes(constraint.len() / 2).unwrap();
         let mask = value.read_bytes(constraint.len() / 2).unwrap();
         Ok((address, mask))

--- a/src/name/verify.rs
+++ b/src/name/verify.rs
@@ -40,7 +40,7 @@ pub fn verify_cert_dns_name(
                         }
                         Some(false) => (),
                         None => {
-                            return NameIteration::Stop(Err(Error::BadDer));
+                            return NameIteration::Stop(Err(Error::BadDER));
                         }
                     }
                 }
@@ -70,7 +70,7 @@ pub fn check_name_constraints(
         if !inner.peek(subtrees_tag.into()) {
             return Ok(None);
         }
-        let subtrees = der::nested(inner, subtrees_tag, Error::BadDer, |tagged| {
+        let subtrees = der::nested(inner, subtrees_tag, Error::BadDER, |tagged| {
             der::expect_tag_and_get_value(tagged, der::Tag::Sequence)
         })?;
         Ok(Some(subtrees))
@@ -152,7 +152,7 @@ fn check_presented_id_conforms_to_constraints_in_subtree(
             input: &mut untrusted::Reader<'b>,
         ) -> Result<GeneralName<'b>, Error> {
             let general_subtree = der::expect_tag_and_get_value(input, der::Tag::Sequence)?;
-            general_subtree.read_all(Error::BadDer, |subtree| general_name(subtree))
+            general_subtree.read_all(Error::BadDER, |subtree| general_name(subtree))
         }
 
         let base = match general_subtree(&mut constraints) {
@@ -164,7 +164,7 @@ fn check_presented_id_conforms_to_constraints_in_subtree(
 
         let matches = match (name, base) {
             (GeneralName::DnsName(name), GeneralName::DnsName(base)) => {
-                dns_name::presented_id_matches_constraint(name, base).ok_or(Error::BadDer)
+                dns_name::presented_id_matches_constraint(name, base).ok_or(Error::BadDER)
             }
 
             (GeneralName::DirectoryName(name), GeneralName::DirectoryName(base)) => Ok(
@@ -322,7 +322,7 @@ fn general_name<'a>(input: &mut untrusted::Reader<'a>) -> Result<GeneralName<'a>
         | UNIFORM_RESOURCE_IDENTIFIER_TAG
         | REGISTERED_ID_TAG => GeneralName::Unsupported(tag & !(CONTEXT_SPECIFIC | CONSTRUCTED)),
 
-        _ => return Err(Error::BadDer),
+        _ => return Err(Error::BadDER),
     };
     Ok(name)
 }

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -175,7 +175,7 @@ struct SubjectPublicKeyInfo<'a> {
 // `PublicKeyAlgorithm` for the `SignatureAlgorithm` that is matched when
 // parsing the signature.
 fn parse_spki_value(input: untrusted::Input) -> Result<SubjectPublicKeyInfo, Error> {
-    input.read_all(Error::BadDer, |input| {
+    input.read_all(Error::BadDER, |input| {
         let algorithm_id_value = der::expect_tag_and_get_value(input, der::Tag::Sequence)?;
         let key_value = der::bit_string_with_no_unused_bits(input)?;
         Ok(SubjectPublicKeyInfo {
@@ -402,7 +402,7 @@ mod tests {
         let tsd = parse_test_signed_data(file_contents);
         let spki_value = untrusted::Input::from(&tsd.spki);
         let spki_value = spki_value
-            .read_all(Error::BadDer, |input| {
+            .read_all(Error::BadDER, |input| {
                 der::expect_tag_and_get_value(input, der::Tag::Sequence)
             })
             .unwrap();
@@ -415,14 +415,14 @@ mod tests {
 
         let algorithm = untrusted::Input::from(&tsd.algorithm);
         let algorithm = algorithm
-            .read_all(Error::BadDer, |input| {
+            .read_all(Error::BadDER, |input| {
                 der::expect_tag_and_get_value(input, der::Tag::Sequence)
             })
             .unwrap();
 
         let signature = untrusted::Input::from(&tsd.signature);
         let signature = signature
-            .read_all(Error::BadDer, |input| {
+            .read_all(Error::BadDER, |input| {
                 der::bit_string_with_no_unused_bits(input)
             })
             .unwrap();
@@ -461,7 +461,7 @@ mod tests {
         let signature = untrusted::Input::from(&tsd.signature);
         assert_eq!(
             Err(expected_error),
-            signature.read_all(Error::BadDer, |input| {
+            signature.read_all(Error::BadDER, |input| {
                 der::bit_string_with_no_unused_bits(input)
             })
         );
@@ -482,7 +482,7 @@ mod tests {
         let spki = untrusted::Input::from(&tsd.spki);
         assert_eq!(
             Err(expected_error),
-            spki.read_all(Error::BadDer, |input| {
+            spki.read_all(Error::BadDER, |input| {
                 der::expect_tag_and_get_value(input, der::Tag::Sequence)
             })
         );
@@ -518,7 +518,7 @@ mod tests {
     test_verify_signed_data_signature_outer!(
         test_ecdsa_prime256v1_sha512_unused_bits_signature,
         "ecdsa-prime256v1-sha512-unused-bits-signature.pem",
-        Error::BadDer
+        Error::BadDER
     );
     // XXX: We should have a variant of this test with a SHA-256 digest that gives
     // `Error::UnsupportedSignatureAlgorithmForPublicKey`.
@@ -571,12 +571,12 @@ mod tests {
     test_parse_spki_bad_outer!(
         test_rsa_pkcs1_sha1_bad_key_der_length,
         "rsa-pkcs1-sha1-bad-key-der-length.pem",
-        Error::BadDer
+        Error::BadDER
     );
     test_parse_spki_bad_outer!(
         test_rsa_pkcs1_sha1_bad_key_der_null,
         "rsa-pkcs1-sha1-bad-key-der-null.pem",
-        Error::BadDer
+        Error::BadDER
     );
     test_verify_signed_data!(
         test_rsa_pkcs1_sha1_key_params_absent,
@@ -610,7 +610,7 @@ mod tests {
     test_parse_spki_bad_outer!(
         test_rsa_pkcs1_sha256_key_encoded_ber,
         "rsa-pkcs1-sha256-key-encoded-ber.pem",
-        Error::BadDer
+        Error::BadDER
     );
     test_verify_signed_data!(
         test_rsa_pkcs1_sha256_spki_non_null_params,

--- a/src/time.rs
+++ b/src/time.rs
@@ -23,6 +23,13 @@
 pub struct Time(u64);
 
 impl Time {
+    /// Deprecated. Use `TryFrom::try_from`.
+    #[cfg(feature = "std")]
+    // Soft deprecation. #[deprecated(note = "Use TryFrom::try_from")]
+    pub fn try_from(time: std::time::SystemTime) -> Result<Self, ring::error::Unspecified> {
+        core::convert::TryFrom::try_from(time)
+    }
+
     /// Create a `webpki::Time` from a unix timestamp.
     ///
     /// It is usually better to use the less error-prone
@@ -37,7 +44,8 @@ impl Time {
 
 #[cfg(feature = "std")]
 impl core::convert::TryFrom<std::time::SystemTime> for Time {
-    type Error = std::time::SystemTimeError;
+    // TODO: In the next release, make this `std::time::SystemTimeError`.
+    type Error = ring::error::Unspecified;
 
     /// Create a `webpki::Time` from a `std::time::SystemTime`.
     ///
@@ -50,9 +58,9 @@ impl core::convert::TryFrom<std::time::SystemTime> for Time {
     /// # extern crate webpki;
     /// #
     /// #![cfg(feature = "std")]
-    /// use std::{convert::TryFrom, time::{SystemTime, SystemTimeError}};
+    /// use std::{convert::TryFrom, time::SystemTime};
     ///
-    /// # fn foo() -> Result<(), SystemTimeError> {
+    /// # fn foo() -> Result<(), ring::error::Unspecified> {
     /// let time = webpki::Time::try_from(SystemTime::now())?;
     /// # Ok(())
     /// # }
@@ -61,5 +69,6 @@ impl core::convert::TryFrom<std::time::SystemTime> for Time {
         value
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| Self::from_seconds_since_unix_epoch(d.as_secs()))
+            .map_err(|_| ring::error::Unspecified)
     }
 }

--- a/src/trust_anchor.rs
+++ b/src/trust_anchor.rs
@@ -28,11 +28,11 @@ pub struct TrustAnchor<'a> {
 
 /// Trust anchors which may be used for authenticating servers.
 #[derive(Debug)]
-pub struct TlsServerTrustAnchors<'a>(pub &'a [TrustAnchor<'a>]);
+pub struct TLSServerTrustAnchors<'a>(pub &'a [TrustAnchor<'a>]);
 
 /// Trust anchors which may be used for authenticating clients.
 #[derive(Debug)]
-pub struct TlsClientTrustAnchors<'a>(pub &'a [TrustAnchor<'a>]);
+pub struct TLSClientTrustAnchors<'a>(pub &'a [TrustAnchor<'a>]);
 
 impl<'a> TrustAnchor<'a> {
     /// Interprets the given DER-encoded certificate as a `TrustAnchor`. The
@@ -57,7 +57,7 @@ impl<'a> TrustAnchor<'a> {
             possibly_invalid_certificate_serial_number,
         ) {
             Ok(cert) => Ok(Self::from(cert)),
-            Err(Error::UnsupportedCertVersion) => parse_cert_v1(cert_der).or(Err(Error::BadDer)),
+            Err(Error::UnsupportedCertVersion) => parse_cert_v1(cert_der).or(Err(Error::BadDER)),
             Err(err) => Err(err),
         }
     }
@@ -86,9 +86,9 @@ impl<'a> From<Cert<'a>> for TrustAnchor<'a> {
 /// Parses a v1 certificate directly into a TrustAnchor.
 fn parse_cert_v1(cert_der: untrusted::Input) -> Result<TrustAnchor, Error> {
     // X.509 Certificate: https://tools.ietf.org/html/rfc5280#section-4.1.
-    cert_der.read_all(Error::BadDer, |cert_der| {
-        der::nested(cert_der, der::Tag::Sequence, Error::BadDer, |cert_der| {
-            let anchor = der::nested(cert_der, der::Tag::Sequence, Error::BadDer, |tbs| {
+    cert_der.read_all(Error::BadDER, |cert_der| {
+        der::nested(cert_der, der::Tag::Sequence, Error::BadDER, |cert_der| {
+            let anchor = der::nested(cert_der, der::Tag::Sequence, Error::BadDER, |tbs| {
                 // The version number field does not appear in v1 certificates.
                 certificate_serial_number(tbs)?;
 

--- a/src/trust_anchor_util.rs
+++ b/src/trust_anchor_util.rs
@@ -1,0 +1,23 @@
+// Copyright 2015-2021 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+//! Deprecated. Use `TrustAnchor`.
+
+use crate::{Error, TrustAnchor};
+
+/// Deprecated. Use TrustAnchor::try_from_cert_der.
+#[deprecated(note = "Use TrustAnchor::try_from_cert_der")]
+pub fn cert_der_as_trust_anchor(cert_der: &[u8]) -> Result<TrustAnchor, Error> {
+    TrustAnchor::try_from_cert_der(cert_der)
+}

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -61,7 +61,7 @@ pub fn build_chain(
 
         let name_constraints = trust_anchor.name_constraints.map(untrusted::Input::from);
 
-        untrusted::read_all_optional(name_constraints, Error::BadDer, |value| {
+        untrusted::read_all_optional(name_constraints, Error::BadDER, |value| {
             name::check_name_constraints(value, &cert)
         })?;
 
@@ -107,7 +107,7 @@ pub fn build_chain(
             }
         }
 
-        untrusted::read_all_optional(potential_issuer.name_constraints, Error::BadDer, |value| {
+        untrusted::read_all_optional(potential_issuer.name_constraints, Error::BadDER, |value| {
             name::check_name_constraints(value, &cert)
         })?;
 
@@ -170,11 +170,11 @@ fn check_issuer_independent_properties(
     // KeyUsage extension.
 
     cert.validity
-        .read_all(Error::BadDer, |value| check_validity(value, time))?;
-    untrusted::read_all_optional(cert.basic_constraints, Error::BadDer, |value| {
+        .read_all(Error::BadDER, |value| check_validity(value, time))?;
+    untrusted::read_all_optional(cert.basic_constraints, Error::BadDER, |value| {
         check_basic_constraints(value, used_as_ca, sub_ca_count)
     })?;
-    untrusted::read_all_optional(cert.eku, Error::BadDer, |value| {
+    untrusted::read_all_optional(cert.eku, Error::BadDER, |value| {
         check_eku(value, required_eku_if_present)
     })?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -41,7 +41,7 @@ pub fn netflix() {
     let ca = include_bytes!("netflix/ca.der");
 
     let anchors = vec![webpki::TrustAnchor::try_from_cert_der(ca).unwrap()];
-    let anchors = webpki::TlsServerTrustAnchors(&anchors);
+    let anchors = webpki::TLSServerTrustAnchors(&anchors);
 
     #[allow(clippy::unreadable_literal)] // TODO: Make this clear.
     let time = webpki::Time::from_seconds_since_unix_epoch(1492441716);
@@ -59,7 +59,7 @@ pub fn ed25519() {
     let ca = include_bytes!("ed25519/ca.der");
 
     let anchors = vec![webpki::TrustAnchor::try_from_cert_der(ca).unwrap()];
-    let anchors = webpki::TlsServerTrustAnchors(&anchors);
+    let anchors = webpki::TLSServerTrustAnchors(&anchors);
 
     #[allow(clippy::unreadable_literal)] // TODO: Make this clear.
     let time = webpki::Time::from_seconds_since_unix_epoch(1547363522);


### PR DESCRIPTION
Make it easier to maintain support for Rustls 0.19.1 by restoring the webpki main branch to a
state compatible with webpki 0.21.4.
