### PR TITLE
update base64 dev-dependency to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ ring = { version = "0.16.19", default-features = false }
 untrusted = "0.7.1"
 
 [dev-dependencies]
-base64 = "0.9.1"
+base64 = "0.13"
 
 [profile.bench]
 opt-level = 3


### PR DESCRIPTION
The only possibly-incompatible change is an updated MSRV in recent base64 releases, but it is now at 1.34.0, which is still lower than the MSRV of webki (1.46.0).