### PR TITLE
Optional serde support for DnsName/DnsNameRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ trust_anchor_util = ["std"]
 
 [dependencies]
 ring = { version = "0.16.19", default-features = false }
+serde = { version = "1.0.127", optional = true }
 untrusted = "0.7.1"
 
 [dev-dependencies]


### PR DESCRIPTION
I would add implement `Serialize`/`Display` for `DnsNameRef` but I figured there was a good reason to not store it as `&str`, and didn't want to bother with refactoring that without talking to anyone.

This adds serde support for both types under an optional feature. It also implements `Display` for `DnsName` since I figured it'd be reasonable to have.