### PR TITLE
Add tests for `{dns_name, ip_address}::presented_id_matches_constraint()`

### DIFF
--- a/src/name/dns_name.rs
+++ b/src/name/dns_name.rs
@@ -785,11 +785,9 @@ mod tests {
                 untrusted::Input::from(reference),
             );
             assert_eq!(
-                actual_result,
-                expected_result,
-                "presented_dns_id_matches_reference_dns_id(\"{:?}\", IDRole::ReferenceID, \"{:?}\")",
-                presented,
-                reference
+                actual_result, expected_result,
+                "presented_id_matches_reference_id(\"{:?}\", \"{:?}\")",
+                presented, reference
             );
         }
     }

--- a/src/name/dns_name.rs
+++ b/src/name/dns_name.rs
@@ -791,4 +791,62 @@ mod tests {
             );
         }
     }
+
+    const PRESENTED_MATCHES_CONTRAINT: &[(&[u8], &[u8], Option<bool>)] = &[
+        // No absolute presented IDs allowed
+        (b".", b"", None),
+        (b"www.example.com.", b"", None),
+        (b"www.example.com.", b"www.example.com.", None),
+        // No absolute contraints allowed
+        (b"www.example.com", b".", None),
+        (b"www.example.com", b"www.example.com.", None),
+        // No wildcard in constraints allowed
+        (b"www.example.com", b"*.example.com", None),
+        // No empty presented IDs allowed
+        (b"", b"", None),
+        // Empty constraints match everything allowed
+        (b"example.com", b"", Some(true)),
+        (b"*.example.com", b"", Some(true)),
+        // Constraints that start with a dot
+        (b"www.example.com", b".example.com", Some(true)),
+        (b"www.example.com", b".EXAMPLE.COM", Some(true)),
+        (b"www.example.com", b".axample.com", Some(false)),
+        (b"www.example.com", b".xample.com", Some(false)),
+        (b"www.example.com", b".exampl.com", Some(false)),
+        (b"badexample.com", b".example.com", Some(false)),
+        // Constraints that do not start with a dot
+        (b"www.example.com", b"example.com", Some(true)),
+        (b"www.example.com", b"EXAMPLE.COM", Some(true)),
+        (b"www.example.com", b"axample.com", Some(false)),
+        (b"www.example.com", b"xample.com", Some(false)),
+        (b"www.example.com", b"exampl.com", Some(false)),
+        (b"badexample.com", b"example.com", Some(false)),
+        // Presented IDs with wildcard
+        (b"*.example.com", b".example.com", Some(true)),
+        (b"*.example.com", b"example.com", Some(true)),
+        (b"*.example.com", b"www.example.com", Some(true)),
+        (b"*.example.com", b"www.EXAMPLE.COM", Some(true)),
+        (b"*.example.com", b"www.axample.com", Some(false)),
+        (b"*.example.com", b".xample.com", Some(false)),
+        (b"*.example.com", b"xample.com", Some(false)),
+        (b"*.example.com", b".exampl.com", Some(false)),
+        (b"*.example.com", b"exampl.com", Some(false)),
+        // Matching IDs
+        (b"www.example.com", b"www.example.com", Some(true)),
+    ];
+
+    #[test]
+    fn presented_matches_constraint_test() {
+        for &(presented, constraint, expected_result) in PRESENTED_MATCHES_CONTRAINT {
+            let actual_result = presented_id_matches_constraint(
+                untrusted::Input::from(presented),
+                untrusted::Input::from(constraint),
+            );
+            assert_eq!(
+                actual_result, expected_result,
+                "presented_id_matches_constraint(\"{:?}\", \"{:?}\")",
+                presented, constraint
+            );
+        }
+    }
 }

--- a/src/name/ip_address.rs
+++ b/src/name/ip_address.rs
@@ -62,3 +62,77 @@ pub(super) fn presented_id_matches_constraint(
 
     Ok(true)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PRESENTED_MATCHES_CONTRAINT: &[(&str, &str, &str, Result<bool, Error>)] = &[
+        // Cannot mix IpV4 with IpV6 and viceversa
+        ("2001:db8::", "8.8.8.8", "255.255.255.255", Ok(false)),
+        ("8.8.8.8", "2001:db8::", "ffff::", Ok(false)),
+        // IpV4
+        ("8.8.8.8", "8.8.8.8", "255.255.255.255", Ok(true)),
+        ("8.8.8.9", "8.8.8.8", "255.255.255.255", Ok(false)),
+        ("8.8.8.9", "8.8.8.8", "255.255.255.254", Ok(true)),
+        ("8.8.8.10", "8.8.8.8", "255.255.255.254", Ok(false)),
+        ("8.8.8.10", "8.8.8.8", "255.255.255.0", Ok(true)),
+        ("8.8.15.10", "8.8.8.8", "255.255.248.0", Ok(true)),
+        ("8.8.16.10", "8.8.8.8", "255.255.248.0", Ok(false)),
+        ("8.8.16.10", "8.8.8.8", "255.255.0.0", Ok(true)),
+        ("8.31.16.10", "8.8.8.8", "255.224.0.0", Ok(true)),
+        ("8.32.16.10", "8.8.8.8", "255.224.0.0", Ok(false)),
+        ("8.32.16.10", "8.8.8.8", "255.0.0.0", Ok(true)),
+        ("63.32.16.10", "8.8.8.8", "192.0.0.0", Ok(true)),
+        ("64.32.16.10", "8.8.8.8", "192.0.0.0", Ok(false)),
+        ("64.32.16.10", "8.8.8.8", "0.0.0.0", Ok(true)),
+        // IpV6
+        ("2001:db8::", "2001:db8::", "ffff:ffff::", Ok(true)),
+        ("2001:db9::", "2001:db8::", "ffff:ffff::", Ok(false)),
+        ("2001:db9::", "2001:db8::", "ffff:fffe::", Ok(true)),
+        ("2001:dba::", "2001:db8::", "ffff:fffe::", Ok(false)),
+        ("2001:dba::", "2001:db8::", "ffff:ff00::", Ok(true)),
+        ("2001:dca::", "2001:db8::", "ffff:fe00::", Ok(true)),
+        ("2001:fca::", "2001:db8::", "ffff:fe00::", Ok(false)),
+        ("2001:fca::", "2001:db8::", "ffff:0000::", Ok(true)),
+        ("2000:fca::", "2001:db8::", "fffe:0000::", Ok(true)),
+        ("2003:fca::", "2001:db8::", "fffe:0000::", Ok(false)),
+        ("2003:fca::", "2001:db8::", "ff00:0000::", Ok(true)),
+        ("1003:fca::", "2001:db8::", "e000:0000::", Ok(false)),
+        ("1003:fca::", "2001:db8::", "0000:0000::", Ok(true)),
+    ];
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn presented_matches_constraint_test() {
+        use std::boxed::Box;
+        use std::net::IpAddr;
+
+        for &(presented, constraint_address, constraint_mask, expected_result) in
+            PRESENTED_MATCHES_CONTRAINT
+        {
+            let presented_bytes: Box<[u8]> = match presented.parse::<IpAddr>().unwrap() {
+                IpAddr::V4(p) => Box::new(p.octets()),
+                IpAddr::V6(p) => Box::new(p.octets()),
+            };
+            let ca_bytes: Box<[u8]> = match constraint_address.parse::<IpAddr>().unwrap() {
+                IpAddr::V4(ca) => Box::new(ca.octets()),
+                IpAddr::V6(ca) => Box::new(ca.octets()),
+            };
+            let cm_bytes: Box<[u8]> = match constraint_mask.parse::<IpAddr>().unwrap() {
+                IpAddr::V4(cm) => Box::new(cm.octets()),
+                IpAddr::V6(cm) => Box::new(cm.octets()),
+            };
+            let constraint_bytes = [ca_bytes, cm_bytes].concat();
+            let actual_result = presented_id_matches_constraint(
+                untrusted::Input::from(&presented_bytes),
+                untrusted::Input::from(&constraint_bytes),
+            );
+            assert_eq!(
+                actual_result, expected_result,
+                "presented_id_matches_constraint(\"{:?}\", \"{:?}\")",
+                presented_bytes, constraint_bytes
+            );
+        }
+    }
+}


### PR DESCRIPTION
Hello, I am interested to see `webpki` IP address support (issue https://github.com/briansmith/webpki/issues/54). After reading https://github.com/briansmith/webpki/issues/54#issuecomment-759848625 I tried to implement some tests. Please let me know how things could be improved in order to move forward the issue.