### PR TITLE
Allow reading certificate validity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub mod trust_anchor_util;
 mod verify_cert;
 
 pub use {
-    end_entity::EndEntityCert,
+    end_entity::{CertValidity, EndEntityCert},
     error::Error,
     name::{DnsNameRef, InvalidDnsNameError},
     signed_data::{


### PR DESCRIPTION
* Add CertValidity type to prevent mixing not_before, not_after in a tuple
* Expose CertValidity type and add function on EndEntityCert for reading it

Should serve as a way for resolving #76 