### PR TITLE
Add support for verifying certificate chain with EKU

### DIFF
--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -181,4 +181,39 @@ impl<'a> EndEntityCert<'a> {
             untrusted::Input::from(signature),
         )
     }
+
+    /// Verifies that the end-entity certificate is valid for use by cert chain
+    ///
+    /// `required_eku` is the Certificate Extended Key Usage Oid in bytes.
+    /// If the certificate is not valid for `required_eku` then this
+    /// fails with `Error::CertNotValidForName`.
+    /// `supported_sig_algs` is the list of signature algorithms that are
+    /// trusted for use in certificate signatures; the end-entity certificate's
+    /// public key is not validated against this list. `trust_anchors` is the
+    /// list of root CAs to trust. `intermediate_certs` is the sequence of
+    /// intermediate certificates that the client sent in the TLS handshake.
+    /// `cert` is the purported end-entity certificate of the client. `time` is
+    /// the time for which the validation is effective (usually the current
+    /// time).
+    ///
+    pub fn verify_is_valid_cert_with_eku(
+        &self,
+        required_eku: &'static [u8],
+        supported_sig_algs: &[&SignatureAlgorithm],
+        trust_anchors: &[crate::TrustAnchor],
+        intermediate_certs: &[&[u8]],
+        time: Time,
+    ) -> Result<(), Error> {
+        let eku = verify_cert::KeyPurposeId::new(required_eku);
+
+        crate::verify_cert::build_chain(
+            eku,
+            supported_sig_algs,
+            trust_anchors,
+            intermediate_certs,
+            &self.inner,
+            time,
+            0,
+        )
+    }
 }

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -257,6 +257,22 @@ pub struct KeyPurposeId {
     oid_value: untrusted::Input<'static>,
 }
 
+impl KeyPurposeId {
+    /// Construct a new `KeyPurposeId`
+    ///
+    /// `oid` is the OBJECT IDENTIFIER in bytes.
+    ///
+    /// For example:
+    /// static EKU_SERVER_AUTH_BYTES: &'static [u8] = &[(40 * 1) + 3, 6, 1, 5, 5, 7, 3, 1];
+    /// let oid = KeyPurposeId::new(EKU_SERVER_AUTH_BYTES);
+    ///
+    pub fn new(oid: &'static [u8]) -> Self {
+        KeyPurposeId {
+            oid_value: untrusted::Input::from(oid),
+        }
+    }
+}
+
 // id-pkix            OBJECT IDENTIFIER ::= { 1 3 6 1 5 5 7 }
 // id-kp              OBJECT IDENTIFIER ::= { id-pkix 3 }
 


### PR DESCRIPTION
There is a use case[(spdm)]( https://www.dmtf.org/sites/default/files/standards/documents/DSP0274_1.2.0WIP.90.pdf#%5B%7B%22num%22%3A178%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C615%2C0%5D) where Certificate Extended Key Usage(EKU) Oid is customized, and EndCertEntity is used to verify certificate chain with customized EKU. But the current EndCertEntity does not expose the verify function with eku. So I made a patch to expose a function called ```verify_is_valid_cert_with_eku``` for EndCertEntity.

What do you think of this?
Any chance we can see add this API in webpki?
