### PR TITLE
CI: Update CI & Clippy config for release/0.22 branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions-rs/toolchain@v1
@@ -22,7 +22,7 @@ jobs:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions-rs/toolchain@v1
@@ -33,13 +33,13 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - run: cargo clippy --all-features ---all-targets -- --deny warnings
+      - run: cargo clippy --all-features --all-targets -- --deny warnings
 
   audit:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions-rs/toolchain@v1
@@ -67,7 +67,7 @@ jobs:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions-rs/toolchain@v1
@@ -81,9 +81,9 @@ jobs:
             ~/.cargo/bin/cargo-deny
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-          key: ${{ runner.os }}-v2-cargo-deny-locked-0.8.5
+          key: ${{ runner.os }}-v2-cargo-deny-locked-0.14.1
 
-      - run: cargo install cargo-deny --locked --vers "0.8.5"
+      - run: cargo install cargo-deny --locked --vers "0.14.1"
 
       - uses: actions/checkout@v2
 
@@ -94,7 +94,7 @@ jobs:
     # Don't run duplicate `push` jobs for the repo owner's PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -162,16 +162,16 @@ jobs:
 
         include:
           - target: arm-unknown-linux-gnueabihf
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
           - target: i686-pc-windows-msvc
             host_os: windows-latest
 
           - target: x86_64-unknown-linux-musl
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
     steps:
       - if: ${{ contains(matrix.host_os, 'ubuntu') }}
@@ -224,7 +224,7 @@ jobs:
         # TODO: targets
         include:
           - target: x86_64-unknown-linux-musl
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
     steps:
       - if: ${{ contains(matrix.host_os, 'ubuntu') }}

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -27,12 +27,32 @@ function install_packages {
 use_clang=
 case $target in
 --target*android*)
-  mkdir -p "${ANDROID_SDK_ROOT}/licenses"
-  android_license_file="${ANDROID_SDK_ROOT}/licenses/android-sdk-license"
+  # https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html says
+  # "Going forward the Android platform will target the most recent LTS NDK,
+  # allowing Rust developers to access platform features sooner. These updates
+  # should occur yearly and will be announced in release notes." Assume that
+  # means that we should always prefer to be using the latest 25.x.y version of
+  # the NDK until the Rust project announces that we should use a higher major
+  # version number.
+  #
+  # TODO: This should probably be implemented as a map of Rust toolchain version
+  # to NDK version; e.g. our MSRV might (only) support an older NDK than the
+  # latest stable Rust toolchain.
+  #
+  # Keep the following line in sync with the corresponding line in cargo.sh.
+  ndk_version=25.2.9519653
+
+  mkdir -p "${ANDROID_HOME}/licenses"
+  android_license_file="${ANDROID_HOME}/licenses/android-sdk-license"
   accept_android_license=24333f8a63b6825ea9c5514f83c2829b004d1fee
   grep --quiet --no-messages "$accept_android_license" "$android_license_file" \
     || echo $accept_android_license  >> "$android_license_file"
-  sudo "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" ndk-bundle
+  "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" "ndk;$ndk_version"
+
+  # XXX: Older Rust toolchain versions link with `-lgcc` instead of `-lunwind`;
+  # see https://github.com/rust-lang/rust/pull/85806.
+  find -L ${ANDROID_NDK_ROOT:-${ANDROID_HOME}/ndk/$ndk_version} -name libunwind.a \
+          -execdir sh -c 'echo "INPUT(-lunwind)" > libgcc.a' \;
   ;;
 esac
 
@@ -65,31 +85,31 @@ case $target in
 --target=i686-unknown-linux-musl|--target=x86_64-unknown-linux-musl)
   use_clang=1
   ;;
+--target=mipsel-unknown-linux-gnu)
+  install_packages \
+    gcc-mipsel-linux-gnu \
+    libc6-dev-mipsel-cross \
+    qemu-user
+  ;;
 --target=wasm32-unknown-unknown)
-  # The version of wasm-bindgen-cli must match the wasm-bindgen version.
-  wasm_bindgen_version=$(cargo metadata --format-version 1 | jq -r '.packages | map(select( .name == "wasm-bindgen")) | map(.version) | .[0]')
-  cargo install wasm-bindgen-cli --vers "$wasm_bindgen_version" --bin wasm-bindgen-test-runner
-  case ${features-} in
-    *wasm32_c*)
-      use_clang=1
-      ;;
-    *)
-      ;;
-  esac
+  cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner
+  use_clang=1
   ;;
 --target=*)
   ;;
 esac
 
-if [ -n "$use_clang" ]; then
-  llvm_version=10
-  if [ -n "${RING_COVERAGE-}" ]; then
-    # https://github.com/rust-lang/rust/pull/79365 upgraded the coverage file
-    # format to one that only LLVM 11+ can use
-    llvm_version=11
-    sudo apt-key add mk/llvm-snapshot.gpg.key
-    sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-$llvm_version main"
-    sudo apt-get update
+case "$OSTYPE" in
+linux*)
+  ubuntu_codename=$(lsb_release --codename --short)
+  llvm_version=15
+  sudo apt-key add mk/llvm-snapshot.gpg.key
+  sudo add-apt-repository "deb http://apt.llvm.org/$ubuntu_codename/ llvm-toolchain-$ubuntu_codename-$llvm_version main"
+  sudo apt-get update
+  # We need to use `llvm-nm` in `mk/check-symbol-prefixes.sh`.
+  install_packages llvm-$llvm_version
+  if [ -n "$use_clang" ]; then
+    install_packages clang-$llvm_version
   fi
-  install_packages clang-$llvm_version llvm-$llvm_version
-fi
+  ;;
+esac

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,14 +27,20 @@
 #![doc(html_root_url = "https://briansmith.org/rustdoc/")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(
+    clippy::clone_on_copy,
+    clippy::derive_partial_eq_without_eq,
     clippy::doc_markdown,
+    clippy::explicit_auto_deref,
     clippy::if_not_else,
     clippy::inline_always,
     clippy::items_after_statements,
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
+    clippy::needless_borrow,
+    clippy::redundant_closure,
     clippy::single_match,
-    clippy::single_match_else
+    clippy::single_match_else,
+    clippy::useless_asref
 )]
 #![deny(clippy::as_conversions)]
 

--- a/tests/dns_name_tests.rs
+++ b/tests/dns_name_tests.rs
@@ -232,6 +232,7 @@ static DNS_NAME_VALIDITY: &[(&[u8], bool)] = &[
 
 // (IP address, is valid DNS name). The comments here refer to the validity of
 // the string as an IP address, not as a DNS name validity.
+#[allow(clippy::octal_escapes)]
 static IP_ADDRESS_DNS_VALIDITY: &[(&[u8], bool)] = &[
     (b"", false),
     (b"1", false),


### PR DESCRIPTION
Jobs just silently wait forever since they are waiting for an 18.04 runner and there are none anymore. Fix that.

Ubuntu 22.04 doesn't have clang-10. Fix that by syncing mk/* with the versions in the *ring* main branch.

To minimize changes to the source code, turn off newer Clippy lints.

Fix typo in `cargo clippy` invocation.

Upgrade to latest cargo deny.