### PR TITLE
CI: Use Ubuntu 22.04 on GitHub Actions & update Clippy config.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   push:
 jobs:
   rustfmt:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: briansmith/actions-rs-toolchain@v1
@@ -20,7 +20,7 @@ jobs:
       - run: cargo fmt --all -- --check
 
   clippy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: briansmith/actions-rs-toolchain@v1
@@ -36,7 +36,7 @@ jobs:
       - run: mk/clippy.sh
 
   audit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: briansmith/actions-rs-toolchain@v1
@@ -63,7 +63,7 @@ jobs:
       - run: cargo audit --deny warnings
 
   deny:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: briansmith/actions-rs-toolchain@v1
@@ -89,7 +89,7 @@ jobs:
 
   # Verify that documentation builds.
   rustdoc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -116,7 +116,7 @@ jobs:
           cargo doc --all-features
 
   package:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: briansmith/actions-rs-toolchain@v1
@@ -172,16 +172,16 @@ jobs:
 
         include:
           - target: arm-unknown-linux-gnueabihf
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
           - target: i686-pc-windows-msvc
             host_os: windows-latest
 
           - target: x86_64-unknown-linux-musl
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
     steps:
       - if: ${{ contains(matrix.host_os, 'ubuntu') }}
@@ -233,7 +233,7 @@ jobs:
         # TODO: targets
         include:
           - target: x86_64-unknown-linux-musl
-            host_os: ubuntu-18.04
+            host_os: ubuntu-22.04
 
     steps:
       - if: ${{ contains(matrix.host_os, 'ubuntu') }}

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ allow = [
     "LicenseRef-ring",
     "LicenseRef-webpki",
     "MIT",
+    "Unicode-DFS-2016",
 ]
 confidence-threshold = 1.0
 

--- a/mk/cargo.sh
+++ b/mk/cargo.sh
@@ -20,12 +20,18 @@ IFS=$'\n\t'
 rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
 qemu_aarch64="qemu-aarch64 -L /usr/aarch64-linux-gnu"
 qemu_arm="qemu-arm -L /usr/arm-linux-gnueabihf"
+qemu_mipsel="qemu-mipsel -L /usr/mipsel-linux-gnu"
 
 # Avoid putting the Android tools in `$PATH` because there are tools in this
 # directory like `clang` that would conflict with the same-named tools that may
 # be needed to compile the build script, or to compile for other targets.
-if [ -n "${ANDROID_SDK_ROOT-}" ]; then
-  android_tools=$ANDROID_SDK_ROOT/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin
+if [ -n "${ANDROID_HOME-}" ]; then
+  # Keep the next line in sync with the corresponding line in install-build-tools.sh.
+  ndk_version=25.2.9519653
+  ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-${ANDROID_HOME}/ndk/$ndk_version}
+fi
+if [ -n "${ANDROID_NDK_ROOT-}" ]; then
+  android_tools=${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin
 fi
 
 for arg in $*; do
@@ -39,12 +45,12 @@ for arg in $*; do
 done
 
 # See comments in install-build-tools.sh.
-llvm_version=12
+llvm_version=15
 
 case $target in
    aarch64-linux-android)
     export CC_aarch64_linux_android=$android_tools/aarch64-linux-android21-clang
-    export AR_aarch64_linux_android=$android_tools/aarch64-linux-android-ar
+    export AR_aarch64_linux_android=$android_tools/llvm-ar
     export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$android_tools/aarch64-linux-android21-clang
     ;;
   aarch64-unknown-linux-gnu)
@@ -67,9 +73,9 @@ case $target in
     export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER="$qemu_arm"
     ;;
   armv7-linux-androideabi)
-    export CC_armv7_linux_androideabi=$android_tools/armv7a-linux-androideabi18-clang
-    export AR_armv7_linux_androideabi=$android_tools/arm-linux-androideabi-ar
-    export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$android_tools/armv7a-linux-androideabi18-clang
+    export CC_armv7_linux_androideabi=$android_tools/armv7a-linux-androideabi19-clang
+    export AR_armv7_linux_androideabi=$android_tools/llvm-ar
+    export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$android_tools/armv7a-linux-androideabi19-clang
     ;;
   armv7-unknown-linux-musleabihf)
     export CC_armv7_unknown_linux_musleabihf=clang-$llvm_version
@@ -86,6 +92,12 @@ case $target in
     export CC_i686_unknown_linux_musl=clang-$llvm_version
     export AR_i686_unknown_linux_musl=llvm-ar-$llvm_version
     export CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_RUSTFLAGS="$rustflags_self_contained"
+    ;;
+  mipsel-unknown-linux-gnu)
+    export CC_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc
+    export AR_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc-ar
+    export CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc
+    export CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER="$qemu_mipsel"
     ;;
   x86_64-unknown-linux-musl)
     export CC_x86_64_unknown_linux_musl=clang-$llvm_version
@@ -132,7 +144,7 @@ if [ -n "${RING_COVERAGE-}" ]; then
   declare -x "${runner_var}=mk/runner ${!runner_var-}"
 
   rustflags_var=CARGO_TARGET_${target_upper}_RUSTFLAGS
-  declare -x "${rustflags_var}=-Zinstrument-coverage ${!rustflags_var-}"
+  declare -x "${rustflags_var}=-Cinstrument-coverage ${!rustflags_var-}"
 fi
 
 cargo "$@"

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -20,13 +20,14 @@ IFS=$'\n\t'
 export NULL=""
 cargo clippy \
   --target-dir=target/clippy \
-  --all-features ---all-targets \
+  --all-features --all-targets \
   -- \
   --deny missing_docs \
   --deny warnings \
   \
   --deny clippy::as_conversions \
   \
+  --allow clippy::explicit_auto_deref \
   --allow clippy::len_without_is_empty \
   --allow clippy::new_without_default \
   --allow clippy::single_match \

--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -27,12 +27,32 @@ function install_packages {
 use_clang=
 case $target in
 --target*android*)
-  mkdir -p "${ANDROID_SDK_ROOT}/licenses"
-  android_license_file="${ANDROID_SDK_ROOT}/licenses/android-sdk-license"
+  # https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html says
+  # "Going forward the Android platform will target the most recent LTS NDK,
+  # allowing Rust developers to access platform features sooner. These updates
+  # should occur yearly and will be announced in release notes." Assume that
+  # means that we should always prefer to be using the latest 25.x.y version of
+  # the NDK until the Rust project announces that we should use a higher major
+  # version number.
+  #
+  # TODO: This should probably be implemented as a map of Rust toolchain version
+  # to NDK version; e.g. our MSRV might (only) support an older NDK than the
+  # latest stable Rust toolchain.
+  #
+  # Keep the following line in sync with the corresponding line in cargo.sh.
+  ndk_version=25.2.9519653
+
+  mkdir -p "${ANDROID_HOME}/licenses"
+  android_license_file="${ANDROID_HOME}/licenses/android-sdk-license"
   accept_android_license=24333f8a63b6825ea9c5514f83c2829b004d1fee
   grep --quiet --no-messages "$accept_android_license" "$android_license_file" \
     || echo $accept_android_license  >> "$android_license_file"
-  "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" ndk-bundle
+  "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" "ndk;$ndk_version"
+
+  # XXX: Older Rust toolchain versions link with `-lgcc` instead of `-lunwind`;
+  # see https://github.com/rust-lang/rust/pull/85806.
+  find -L ${ANDROID_NDK_ROOT:-${ANDROID_HOME}/ndk/$ndk_version} -name libunwind.a \
+          -execdir sh -c 'echo "INPUT(-lunwind)" > libgcc.a' \;
   ;;
 esac
 
@@ -65,28 +85,31 @@ case $target in
 --target=i686-unknown-linux-musl|--target=x86_64-unknown-linux-musl)
   use_clang=1
   ;;
+--target=mipsel-unknown-linux-gnu)
+  install_packages \
+    gcc-mipsel-linux-gnu \
+    libc6-dev-mipsel-cross \
+    qemu-user
+  ;;
 --target=wasm32-unknown-unknown)
-  # The version of wasm-bindgen-cli must match the wasm-bindgen version.
-  wasm_bindgen_version=$(cargo metadata --format-version 1 | jq -r '.packages | map(select( .name == "wasm-bindgen")) | map(.version) | .[0]')
-  cargo install wasm-bindgen-cli --vers "$wasm_bindgen_version" --bin wasm-bindgen-test-runner
-  case ${features-} in
-    *wasm32_c*)
-      use_clang=1
-      ;;
-    *)
-      ;;
-  esac
+  cargo install wasm-bindgen-cli --bin wasm-bindgen-test-runner
+  use_clang=1
   ;;
 --target=*)
   ;;
 esac
 
-if [ -n "$use_clang" ]; then
-  # https://github.com/rust-lang/rust/pull/79365 upgraded the coverage file
-  # format to one that only LLVM 11+ can use
-  llvm_version=12
+case "$OSTYPE" in
+linux*)
+  ubuntu_codename=$(lsb_release --codename --short)
+  llvm_version=15
   sudo apt-key add mk/llvm-snapshot.gpg.key
-  sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-$llvm_version main"
+  sudo add-apt-repository "deb http://apt.llvm.org/$ubuntu_codename/ llvm-toolchain-$ubuntu_codename-$llvm_version main"
   sudo apt-get update
-  install_packages clang-$llvm_version llvm-$llvm_version
-fi
+  # We need to use `llvm-nm` in `mk/check-symbol-prefixes.sh`.
+  install_packages llvm-$llvm_version
+  if [ -n "$use_clang" ]; then
+    install_packages clang-$llvm_version
+  fi
+  ;;
+esac

--- a/tests/dns_name_tests.rs
+++ b/tests/dns_name_tests.rs
@@ -250,7 +250,7 @@ static IP_ADDRESS_DNS_VALIDITY: &[(&[u8], bool)] = &[
     (b"1.2.3.4\n", false),
     // Nulls not allowed
     (b"\0", false),
-    (b"\01.2.3.4", false),
+    (b"\x001.2.3.4", false),
     (b"1.2.3.4\0", false),
     (b"1.2.3.4\0.5", false),
     // Range
@@ -389,7 +389,7 @@ static IP_ADDRESS_DNS_VALIDITY: &[(&[u8], bool)] = &[
     (b"::1\0:2", false),
     (b"::1\0", false),
     (b"::1.2.3.4\0", false),
-    (b"::1.2\02.3.4", false),
+    (b"::1.2\x002.3.4", false),
 ];
 
 #[test]


### PR DESCRIPTION
Get all GitHub Actions jobs passing again.

There are no Ubuntu 18.04 runners in GitHub Actions anymore, so use 22.04.

Update mk/* scripts to match what's in *ring*'s main branch; some of these changes are required for Ubuntu 22.04. This also fixes a typo in the invocation of `cargo clippy`.

Temporarily allow `clippy::explicit_auto_deref` to avoid source code changes prior to the next 0.22.1 release. Tweak `dns_names_test.rs` so that it doesn't trigger `clippy::octal_escapes` false positives.

Update `cargo deny` to the latest release and update deny.toml so that the Unicode license will be accepted, matching *ring*'s configuration.