### PR TITLE
Clean up Clippy and Rustdoc configuration.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@
 authors = ["Brian Smith <brian@briansmith.org>"]
 categories = ["cryptography", "no-std"]
 description = "Web PKI X.509 Certificate Verification."
-documentation = "https://briansmith.org/rustdoc/webpki/"
 edition = "2018"
 license-file = "LICENSE"
 name = "webpki"

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -35,5 +35,4 @@ cargo clippy \
   --allow clippy::too_many_arguments \
   --allow clippy::type_complexity \
   --allow clippy::upper_case_acronyms \
-  --allow clippy::useless_asref \
   $NULL

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -26,7 +26,6 @@ cargo clippy \
   \
   --deny clippy::as_conversions \
   \
-  --allow clippy::clone_on_copy \
   --allow clippy::explicit_auto_deref \
   --allow clippy::too_many_arguments \
   $NULL

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -28,11 +28,5 @@ cargo clippy \
   \
   --allow clippy::clone_on_copy \
   --allow clippy::explicit_auto_deref \
-  --allow clippy::len_without_is_empty \
-  --allow clippy::new_without_default \
-  --allow clippy::single_match \
-  --allow clippy::single_match_else \
   --allow clippy::too_many_arguments \
-  --allow clippy::type_complexity \
-  --allow clippy::upper_case_acronyms \
   $NULL

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -26,6 +26,5 @@ cargo clippy \
   \
   --deny clippy::as_conversions \
   \
-  --allow clippy::explicit_auto_deref \
   --allow clippy::too_many_arguments \
   $NULL

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -29,7 +29,6 @@ cargo clippy \
   --allow clippy::clone_on_copy \
   --allow clippy::explicit_auto_deref \
   --allow clippy::len_without_is_empty \
-  --allow clippy::needless_borrow \
   --allow clippy::new_without_default \
   --allow clippy::octal_escapes \
   --allow clippy::redundant_closure \

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -30,7 +30,6 @@ cargo clippy \
   --allow clippy::explicit_auto_deref \
   --allow clippy::len_without_is_empty \
   --allow clippy::new_without_default \
-  --allow clippy::octal_escapes \
   --allow clippy::redundant_closure \
   --allow clippy::single_match \
   --allow clippy::single_match_else \

--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -30,7 +30,6 @@ cargo clippy \
   --allow clippy::explicit_auto_deref \
   --allow clippy::len_without_is_empty \
   --allow clippy::new_without_default \
-  --allow clippy::redundant_closure \
   --allow clippy::single_match \
   --allow clippy::single_match_else \
   --allow clippy::too_many_arguments \

--- a/src/end_entity.rs
+++ b/src/end_entity.rs
@@ -139,7 +139,7 @@ impl<'a> EndEntityCert<'a> {
 
     /// Verifies that the certificate is valid for the given DNS host name.
     pub fn verify_is_valid_for_dns_name(&self, dns_name: DnsNameRef) -> Result<(), Error> {
-        name::verify_cert_dns_name(&self, dns_name)
+        name::verify_cert_dns_name(self, dns_name)
     }
 
     /// Verifies that the certificate is valid for at least one of the given DNS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! | `alloc` | Enable features that require use of the heap. Currently all RSA signature algorithms require this feature. |
 //! | `std` | Enable features that require libstd. Implies `alloc`. |
 
-#![doc(html_root_url = "https://briansmith.org/rustdoc/")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(
     clippy::doc_markdown,

--- a/src/name/dns_name.rs
+++ b/src/name/dns_name.rs
@@ -125,7 +125,7 @@ impl<'a> DnsNameRef<'a> {
     pub fn to_owned(&self) -> DnsName {
         // DnsNameRef is already guaranteed to be valid ASCII, which is a
         // subset of UTF-8.
-        let s: &str = self.clone().into();
+        let s: &str = (*self).into();
         DnsName(s.to_ascii_lowercase())
     }
 }

--- a/src/name/verify.rs
+++ b/src/name/verify.rs
@@ -152,7 +152,7 @@ fn check_presented_id_conforms_to_constraints_in_subtree(
             input: &mut untrusted::Reader<'b>,
         ) -> Result<GeneralName<'b>, Error> {
             let general_subtree = der::expect_tag_and_get_value(input, der::Tag::Sequence)?;
-            general_subtree.read_all(Error::BadDer, |subtree| general_name(subtree))
+            general_subtree.read_all(Error::BadDer, general_name)
         }
 
         let base = match general_subtree(&mut constraints) {

--- a/src/name/verify.rs
+++ b/src/name/verify.rs
@@ -26,7 +26,7 @@ pub fn verify_cert_dns_name(
     dns_name: DnsNameRef,
 ) -> Result<(), Error> {
     let cert = cert.inner();
-    let dns_name = untrusted::Input::from(dns_name.as_ref().as_ref());
+    let dns_name = untrusted::Input::from(dns_name.as_ref());
     iterate_names(
         cert.subject,
         cert.subject_alt_name,

--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -755,7 +755,7 @@ mod tests {
             if line == end_section {
                 break;
             }
-            base64.push_str(&line);
+            base64.push_str(line);
         }
 
         base64::decode(&base64).unwrap()

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -125,7 +125,7 @@ fn build_chain_inner(
         let name_constraints = trust_anchor.name_constraints.map(untrusted::Input::from);
 
         untrusted::read_all_optional(name_constraints, Error::BadDer, |value| {
-            name::check_name_constraints(value, &cert)
+            name::check_name_constraints(value, cert)
         })?;
 
         let trust_anchor_spki = untrusted::Input::from(trust_anchor.spki);
@@ -149,7 +149,7 @@ fn build_chain_inner(
 
     loop_while_non_fatal_error(intermediate_certs, |cert_der| {
         let potential_issuer =
-            cert::parse_cert(untrusted::Input::from(*cert_der), EndEntityOrCa::Ca(&cert))?;
+            cert::parse_cert(untrusted::Input::from(*cert_der), EndEntityOrCa::Ca(cert))?;
 
         if potential_issuer.subject != cert.issuer {
             return Err(Error::UnknownIssuer.into());
@@ -174,7 +174,7 @@ fn build_chain_inner(
         }
 
         untrusted::read_all_optional(potential_issuer.name_constraints, Error::BadDer, |value| {
-            name::check_name_constraints(value, &cert)
+            name::check_name_constraints(value, cert)
         })?;
 
         let next_sub_ca_count = match used_as_ca {

--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -149,7 +149,7 @@ fn build_chain_inner(
 
     loop_while_non_fatal_error(intermediate_certs, |cert_der| {
         let potential_issuer =
-            cert::parse_cert(untrusted::Input::from(*cert_der), EndEntityOrCa::Ca(cert))?;
+            cert::parse_cert(untrusted::Input::from(cert_der), EndEntityOrCa::Ca(cert))?;
 
         if potential_issuer.subject != cert.issuer {
             return Err(Error::UnknownIssuer.into());

--- a/tests/dns_name_tests.rs
+++ b/tests/dns_name_tests.rs
@@ -250,7 +250,7 @@ static IP_ADDRESS_DNS_VALIDITY: &[(&[u8], bool)] = &[
     (b"1.2.3.4\n", false),
     // Nulls not allowed
     (b"\0", false),
-    (b"\01.2.3.4", false),
+    (b"\x001.2.3.4", false),
     (b"1.2.3.4\0", false),
     (b"1.2.3.4\0.5", false),
     // Range
@@ -389,7 +389,7 @@ static IP_ADDRESS_DNS_VALIDITY: &[(&[u8], bool)] = &[
     (b"::1\0:2", false),
     (b"::1\0", false),
     (b"::1.2.3.4\0", false),
-    (b"::1.2\02.3.4", false),
+    (b"::1.2\x002.3.4", false),
 ];
 
 #[test]


### PR DESCRIPTION
Address almost all the Clippy lints and remove their `allow`s. Remove the `briansmith.org` rustdoc references.