### PR TITLE
backport rustls/webpki path complexity budget

### DIFF
--- a/src/verify_cert.rs
+++ b/src/verify_cert.rs
@@ -243,7 +243,13 @@ impl Budget {
 
 impl Default for Budget {
     fn default() -> Self {
-        Self { signatures: 100 }
+        Self {
+            // This limit is taken from the remediation for golang CVE-2018-16875.  However,
+            // note that golang subsequently implemented AKID matching due to this limit
+            // being hit in real applications (see <https://github.com/spiffe/spire/issues/1004>).
+            // So this may actually be too aggressive.
+            signatures: 100,
+        }
     }
 }
 


### PR DESCRIPTION
This is intended to be complementary to the signature validation limit fix (https://github.com/briansmith/webpki/pull/273) and addresses https://github.com/briansmith/webpki/issues/276 in the same manner as NSS libmozpkix. Originally implemented by @ctz in https://github.com/rustls/webpki/pull/163.

Ive backported the change, adapting it to this repository's `main` branch and folded in some later improvements that were made after rustls/webpki#163 (e.g. cleaning up imports, using a more readable numeric literal, fixing the unit test).