### PR TITLE
verify_cert: check name constraints after sig. validation

### DIFF
--- a/src/signed_data.rs
+++ b/src/signed_data.rs
@@ -48,6 +48,7 @@ pub struct SignedData<'a> {
 ///     signatureAlgorithm AlgorithmIdentifier,
 ///     signatureValue BIT STRING
 /// }
+/// ```
 ///
 /// OCSP responses (RFC 6960) look like this:
 /// ```ASN.1


### PR DESCRIPTION

Prior to this branch parsing and processing certificate name constraints was done before validating a chain of signatures to a known trust anchor. This increases the attack surface of these features, allowing an adversary to force webpki to process name constraints on a crafted certificate without needing to have that certificate issued by a trusted entity.

This branch moves the parsing and processing of name constraints to after building and verifying the chain of signatures to reduce the potential for mischief. It's a backport of part of the work from https://github.com/rustls/webpki/pull/165, however test coverage and constraining the number of comparisons using a budget limit are omitted due to the general state of name constraint support (c.f. https://github.com/briansmith/webpki/pull/226).
