### PR TITLE
Tidy up budget enforcement

### DIFF
--- a/mk/clippy.sh
+++ b/mk/clippy.sh
@@ -25,6 +25,4 @@ cargo clippy \
   --deny warnings \
   \
   --deny clippy::as_conversions \
-  \
-  --allow clippy::too_many_arguments \
   $NULL

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -52,7 +52,7 @@ impl Default for Budget {
             // So this may actually be too aggressive.
             signatures: 100,
 
-            // This limit is taken from NSS libmozpkix, see:
+            // This limit is taken from mozilla::pkix, see:
             // <https://github.com/nss-dev/nss/blob/bb4a1d38dd9e92923525ac6b5ed0288479f3f3fc/lib/mozpkix/lib/pkixbuild.cpp#L381-L393>
             build_chain_calls: 200_000,
         }

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -23,21 +23,24 @@ pub(super) struct Budget {
 impl Budget {
     #[inline]
     pub fn consume_signature(&mut self) -> Result<(), InternalError> {
-        self.signatures = self
-            .signatures
-            .checked_sub(1)
-            .ok_or(InternalError::MaximumSignatureChecksExceeded)?;
-        Ok(())
+        checked_sub(
+            &mut self.signatures,
+            InternalError::MaximumSignatureChecksExceeded,
+        )
     }
 
     #[inline]
     pub fn consume_build_chain_call(&mut self) -> Result<(), InternalError> {
-        self.build_chain_calls = self
-            .build_chain_calls
-            .checked_sub(1)
-            .ok_or(InternalError::MaximumPathBuildCallsExceeded)?;
-        Ok(())
+        checked_sub(
+            &mut self.build_chain_calls,
+            InternalError::MaximumPathBuildCallsExceeded,
+        )
     }
+}
+
+fn checked_sub(value: &mut usize, underflow_error: InternalError) -> Result<(), InternalError> {
+    *value = value.checked_sub(1).ok_or(underflow_error)?;
+    Ok(())
 }
 
 impl Default for Budget {

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -1,0 +1,57 @@
+// Copyright 2015 Brian Smith.
+// Portions Copyright 2033 Daniel McCarney.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use crate::error::InternalError;
+
+pub(super) struct Budget {
+    signatures: usize,
+    build_chain_calls: usize,
+}
+
+impl Budget {
+    #[inline]
+    pub fn consume_signature(&mut self) -> Result<(), InternalError> {
+        self.signatures = self
+            .signatures
+            .checked_sub(1)
+            .ok_or(InternalError::MaximumSignatureChecksExceeded)?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn consume_build_chain_call(&mut self) -> Result<(), InternalError> {
+        self.build_chain_calls = self
+            .build_chain_calls
+            .checked_sub(1)
+            .ok_or(InternalError::MaximumPathBuildCallsExceeded)?;
+        Ok(())
+    }
+}
+
+impl Default for Budget {
+    fn default() -> Self {
+        Self {
+            // This limit is taken from the remediation for golang CVE-2018-16875.  However,
+            // note that golang subsequently implemented AKID matching due to this limit
+            // being hit in real applications (see <https://github.com/spiffe/spire/issues/1004>).
+            // So this may actually be too aggressive.
+            signatures: 100,
+
+            // This limit is taken from NSS libmozpkix, see:
+            // <https://github.com/nss-dev/nss/blob/bb4a1d38dd9e92923525ac6b5ed0288479f3f3fc/lib/mozpkix/lib/pkixbuild.cpp#L381-L393>
+            build_chain_calls: 200_000,
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,6 +116,15 @@ pub(crate) enum InternalError {
     MaximumPathBuildCallsExceeded,
 }
 
+impl InternalError {
+    fn is_fatal(&self) -> bool {
+        matches!(
+            self,
+            Self::MaximumSignatureChecksExceeded | Self::MaximumPathBuildCallsExceeded
+        )
+    }
+}
+
 pub(crate) enum ErrorOrInternalError {
     Error(Error),
     InternalError(InternalError),
@@ -125,10 +134,7 @@ impl ErrorOrInternalError {
     pub fn is_fatal(&self) -> bool {
         match self {
             ErrorOrInternalError::Error(_) => false,
-            ErrorOrInternalError::InternalError(InternalError::MaximumSignatureChecksExceeded)
-            | ErrorOrInternalError::InternalError(InternalError::MaximumPathBuildCallsExceeded) => {
-                true
-            }
+            ErrorOrInternalError::InternalError(e) => e.is_fatal(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@
 #[cfg_attr(test, macro_use)]
 extern crate alloc;
 
+mod budget;
+
 #[macro_use]
 mod der;
 


### PR DESCRIPTION
These are non-functional changes designed to clarify how the budget is encapsulated, along with some other tidying that I noticed was appropriate during the review of PR #277.

It is best to review this commit-by-commit.