### PR TITLE
Cargo: unpin rcgen dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ untrusted = "0.7.1"
 
 [dev-dependencies]
 base64 = "0.9.1"
-rcgen = { version = "=0.11.1", default-features = false }
+rcgen = { version = "0.11.3", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
Follow-up from https://github.com/briansmith/webpki/pull/280

Rcgen 0.11.3 has been released and fixed the semver breakage that required temporarily pinning to 0.11.1.