### PR TITLE
Upgrade to *ring* 0.17 and untrusted 0.9.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ alloc = ["ring/alloc"]
 std = ["alloc"]
 
 [dependencies]
-ring = { version = "0.16.19", default-features = false }
-untrusted = "0.7.1"
+ring = { version = "0.17.0", default-features = false }
+untrusted = "0.9"
 
 [dev-dependencies]
 base64 = "0.9.1"

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -12,7 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-use crate::{der, signed_data, Error};
+use crate::{der, equal, signed_data, Error};
 
 pub enum EndEntityOrCa<'a> {
     EndEntity,
@@ -66,7 +66,7 @@ pub(crate) fn parse_cert_internal<'a>(
         // TODO: In mozilla::pkix, the comparison is done based on the
         // normalized value (ignoring whether or not there is an optional NULL
         // parameter for RSA-based algorithms), so this may be too strict.
-        if signature != signed_data.algorithm {
+        if !equal(signature, signed_data.algorithm) {
             return Err(Error::SignatureAlgorithmMismatch);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,3 +95,9 @@ pub type TLSServerTrustAnchors<'a> = TlsServerTrustAnchors<'a>;
 #[deprecated(note = "use TlsClientTrustAnchors")]
 #[allow(unknown_lints, clippy::upper_case_acronyms)]
 pub type TLSClientTrustAnchors<'a> = TlsClientTrustAnchors<'a>;
+
+// We don't operate on secret data so a convenient comparison function is warranted.
+#[must_use]
+fn equal(a: untrusted::Input, b: untrusted::Input) -> bool {
+    a.as_slice_less_safe() == b.as_slice_less_safe()
+}

--- a/src/name/verify.rs
+++ b/src/name/verify.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{
     cert::{Cert, EndEntityOrCa},
-    der, Error,
+    der, equal, Error,
 };
 
 pub fn verify_cert_dns_name(
@@ -234,7 +234,7 @@ fn presented_directory_name_matches_constraint(
     subtrees: Subtrees,
 ) -> bool {
     match subtrees {
-        Subtrees::PermittedSubtrees => name == constraint,
+        Subtrees::PermittedSubtrees => equal(name, constraint),
         Subtrees::ExcludedSubtrees => true,
     }
 }


### PR DESCRIPTION
untrusted 0.9 is used by *ring*. untrusted stopped providing a `PartialEq` for `Input` in 0.9; this was the driver for all the code changes.