### PR TITLE
CI: Test all the non-wasm32 targets that *ring*'s CI tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,25 +113,16 @@ jobs:
           - --all-features
 
         target:
-          - aarch64-apple-ios
           - aarch64-apple-darwin
           - aarch64-linux-android
           - aarch64-pc-windows-msvc
           - aarch64-unknown-linux-gnu
-          - aarch64-unknown-linux-musl
-          - arm-unknown-linux-gnueabi
-          - armv7-linux-androideabi
           - armv7-unknown-linux-musleabihf
           - i686-pc-windows-msvc
-          - i686-unknown-linux-gnu
-          - i686-unknown-linux-musl
-          - powerpc-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
           - wasm32-wasi
-          - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
-          - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
 
         mode:
@@ -149,11 +140,6 @@ jobs:
           - target: aarch64-apple-darwin
             host_os: macos-13-xlarge
 
-          - target: aarch64-apple-ios
-            host_os: macos-13
-            # TODO: Run in the emulator.
-            cargo_options: --no-run
-
           - target: aarch64-linux-android
             host_os: ubuntu-22.04
             # TODO: https://github.com/briansmith/ring/issues/486
@@ -167,31 +153,11 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             host_os: ubuntu-22.04
 
-          - target: aarch64-unknown-linux-musl
-            host_os: ubuntu-22.04
-
-          - target: arm-unknown-linux-gnueabi
-            host_os: ubuntu-22.04
-
-          - target: armv7-linux-androideabi
-            host_os: ubuntu-22.04
-            # TODO: https://github.com/briansmith/ring/issues/838
-            cargo_options: --no-run
-
           - target: armv7-unknown-linux-musleabihf
             host_os: ubuntu-22.04
 
           - target: i686-pc-windows-msvc
             host_os: windows-latest
-
-          - target: i686-unknown-linux-gnu
-            host_os: ubuntu-22.04
-
-          - target: i686-unknown-linux-musl
-            host_os: ubuntu-22.04
-
-          - target: powerpc-unknown-linux-gnu
-            host_os: ubuntu-22.04
 
           - target: riscv64gc-unknown-linux-gnu
             host_os: ubuntu-22.04
@@ -199,17 +165,11 @@ jobs:
           - target: wasm32-wasi
             host_os: ubuntu-22.04
 
-          - target: x86_64-pc-windows-gnu
-            host_os: windows-latest
-
           - target: x86_64-pc-windows-msvc
             host_os: windows-latest
 
           - target: x86_64-apple-darwin
             host_os: macos-13
-
-          - target: x86_64-unknown-linux-musl
-            host_os: ubuntu-22.04
 
           - target: x86_64-unknown-linux-gnu
             host_os: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,24 @@ jobs:
           - --all-features
 
         target:
-          # There is no platform-specific code in webpki. Choose a handful of
-          # platforms mostly to smoketest that the build machinery in mk/ is
-          # portable.
-          # Specifically choose `aarch64-pc-windows-msvc` since it was new in
-          # *ring* 0.17.
+          - aarch64-apple-ios
+          - aarch64-apple-darwin
+          - aarch64-linux-android
           - aarch64-pc-windows-msvc
-          - arm-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - arm-unknown-linux-gnueabi
+          - armv7-linux-androideabi
+          - armv7-unknown-linux-musleabihf
           - i686-pc-windows-msvc
+          - i686-unknown-linux-gnu
+          - i686-unknown-linux-musl
+          - powerpc-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          - wasm32-wasi
+          - x86_64-pc-windows-gnu
+          - x86_64-pc-windows-msvc
+          - x86_64-apple-darwin
           - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
 
@@ -130,23 +140,73 @@ jobs:
 
         rust_channel:
           - stable
+          # Keep in sync with Cargo.toml and similar `rust_channel` sections.
+          - 1.61.0 # MSRV
           - nightly
-
-          - 1.61.0
-
           - beta
 
         include:
+          - target: aarch64-apple-darwin
+            host_os: macos-13-xlarge
+
+          - target: aarch64-apple-ios
+            host_os: macos-13
+            # TODO: Run in the emulator.
+            cargo_options: --no-run
+
+          - target: aarch64-linux-android
+            host_os: ubuntu-22.04
+            # TODO: https://github.com/briansmith/ring/issues/486
+            cargo_options: --no-run
+
           - target: aarch64-pc-windows-msvc
             host_os: windows-latest
             # GitHub Actions doesn't have a way to run this target yet.
             cargo_options: --no-run
 
-          - target: arm-unknown-linux-gnueabihf
+          - target: aarch64-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: aarch64-unknown-linux-musl
+            host_os: ubuntu-22.04
+
+          - target: arm-unknown-linux-gnueabi
+            host_os: ubuntu-22.04
+
+          - target: armv7-linux-androideabi
+            host_os: ubuntu-22.04
+            # TODO: https://github.com/briansmith/ring/issues/838
+            cargo_options: --no-run
+
+          - target: armv7-unknown-linux-musleabihf
             host_os: ubuntu-22.04
 
           - target: i686-pc-windows-msvc
             host_os: windows-latest
+
+          - target: i686-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: i686-unknown-linux-musl
+            host_os: ubuntu-22.04
+
+          - target: powerpc-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: riscv64gc-unknown-linux-gnu
+            host_os: ubuntu-22.04
+
+          - target: wasm32-wasi
+            host_os: ubuntu-22.04
+
+          - target: x86_64-pc-windows-gnu
+            host_os: windows-latest
+
+          - target: x86_64-pc-windows-msvc
+            host_os: windows-latest
+
+          - target: x86_64-apple-darwin
+            host_os: macos-13
 
           - target: x86_64-unknown-linux-musl
             host_os: ubuntu-22.04
@@ -167,6 +227,9 @@ jobs:
 
       - if: ${{ !contains(matrix.host_os, 'windows') }}
         run: mk/install-build-tools.sh --target=${{ matrix.target }} ${{ matrix.features }}
+
+      - if: ${{ contains(matrix.host_os, 'windows') }}
+        run: ./mk/install-build-tools.ps1
 
       - if: ${{ matrix.target == 'aarch64-pc-windows-msvc' }}
         run: |
@@ -190,6 +253,12 @@ jobs:
       - if: ${{ contains(matrix.host_os, 'windows') && !contains(matrix.rust_channel, '1.61.0') && !contains(matrix.target, 'aarch64-pc-windows-msvc') }}
         run: |
           cargo +${{ matrix.rust_channel }} test -vv -p rcgen-tests --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
+
+      # --all-targets doesn't run doctests: https://github.com/rust-lang/cargo/issues/6669
+      # Run doctests only on x86_64 to avoid cross-compilation hassles with `--no-run`.
+      - if: ${{ !contains(matrix.host_os, 'windows') && contains(matrix.target, 'x86_64') }}
+        run: |
+          mk/cargo.sh +${{ matrix.rust_channel }} test -vv --doc --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
 
   coverage:
     runs-on: ${{ matrix.host_os }}


### PR DESCRIPTION
In particular, add testing on aarch64-apple-darwin.